### PR TITLE
Remove required version of ScanCode

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-scancode-toolkit<=21.3.31
+scancode-toolkit
 typecode_libmagic
 XlsxWriter
 fosslight_util>=1.1.0


### PR DESCRIPTION
## Description
The installed version of ScanCode is limited to version 21.3.31 or lower.
However, the package used for version 21.3.31 has been deleted recently, so it cannot be executed.
Therefore, the version restriction was removed so that ScanCode can be installed with the latest version.

- Error Message
```
  File "/usr/lib/python3.6/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "fosslight_source_scanner/.tox/test_run/lib/python3.6/site-packages/packagedcode/__init__.py", line 15, in <module>
    from packagedcode import debian
  File "fosslight_source_scanner/.tox/test_run/lib/python3.6/site-packages/packagedcode/debian.py", line 14, in <module>
    from debut import debcon
ModuleNotFoundError: No module named 'debut'
```

## Type of change
Please insert 'x' one of the type of change.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

