### PR TITLE
Add python version to github PR action

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6]
+        python-version: [3.6, 3.7]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,6 @@ skipdist = true
 
 [testenv]
 install_command = pip install {opts} {packages}
-basepython= python3.6
 whitelist_externals = cat
 setenv =
   PYTHONPATH=.


### PR DESCRIPTION
## Description
<!--
Please describe what this PR do.
 -->
FOSSLight Source Scanner is going to have different packages that are additionally installed in python 3.6, 3.6 or later versions.
- Add Python 3.7 to your Python test.
- Remove basepython version from tox.

## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

