### PR TITLE
Change only ScanCode to print comments

### DIFF
--- a/src/fosslight_source/_parsing_scanoss_file.py
+++ b/src/fosslight_source/_parsing_scanoss_file.py
@@ -43,17 +43,17 @@ def parsing_scanResult(scanoss_report):
         if is_exclude_file(file_path):
             result_item.set_exclude(True)
 
-        comment = ""
-        comment += "Match Type : " + findings[0]['id'] + ", "
         if 'vendor' in findings[0]:
-            comment += "Vendor : " + findings[0]['vendor'] + ", "
+            result_item.set_vendor(findings[0]['vendor'])
         if 'file_url' in findings[0]:
-            comment += "File URL : " + findings[0]['file_url'] + ", "
+            result_item.set_fileURL(findings[0]['file_url'])
         if 'matched' in findings[0]:
-            comment += "Matched : " + findings[0]['matched'] + ", "
-        if 'lines' in findings[0]:
-            comment += "Lines : " + findings[0]['lines']
-        result_item.set_comment(comment)
+            if 'lines' in findings[0]:
+                result_item.set_matched_lines(findings[0]['matched'] + " (" + findings[0]['lines'] + ")")
+            else:
+                result_item.set_matched_lines(findings[0]['matched'])
+        elif 'lines' in findings[0]:
+            result_item.set_matched_lines("(" + findings[0]['lines'] + ")")
 
         scanoss_file_item.append(result_item)
 

--- a/src/fosslight_source/_scan_item.py
+++ b/src/fosslight_source/_scan_item.py
@@ -29,6 +29,9 @@ class ScanItem:
     oss_name = ""
     oss_version = ""
     download_location = ""
+    matched_lines = ""  # for scanoss
+    fileURL = ""  # for scanoss
+    vendor = ""  # for scanoss
 
     def __init__(self, value):
         self.file = value
@@ -71,6 +74,15 @@ class ScanItem:
 
     def set_download_location(self, value):
         self.download_location = value
+
+    def set_matched_lines(self, value):
+        self.matched_lines = value
+
+    def set_fileURL(self, value):
+        self.fileURL = value
+
+    def set_vendor(self, value):
+        self.vendor = value
 
     def get_row_to_print(self):
         if not self.download_location:


### PR DESCRIPTION
## Description
- Change only ScanCode to print comments.
- Store vendor, fileURL, matched_line in separate variables for Scanoss.

## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

