### PR TITLE
Add license reference column

### DIFF
--- a/src/fosslight_source/_scan_item.py
+++ b/src/fosslight_source/_scan_item.py
@@ -32,6 +32,7 @@ class ScanItem:
     matched_lines = ""
     fileURL = ""
     vendor = ""
+    license_reference = ""
 
     def __init__(self, value):
         self.file = value
@@ -84,6 +85,9 @@ class ScanItem:
     def set_vendor(self, value):
         self.vendor = value
 
+    def set_license_reference(self, value):
+        self.license_reference = value
+
     def get_row_to_print(self):
         print_rows = [self.file, self.oss_name, self.oss_version, ','.join(self.licenses), self.download_location, "",
                       ','.join(self.copyright),
@@ -98,12 +102,20 @@ class ScanItem:
                       self.comment, self.matched_lines, self.fileURL, self.vendor]
         return print_rows
 
+    def get_row_to_print_for_all_scanner(self):
+        print_rows = [self.file, self.oss_name, self.oss_version, ','.join(self.licenses), self.download_location, "",
+                      ','.join(self.copyright),
+                      "Exclude" if self.exclude else "",
+                      self.comment, self.license_reference, self.matched_lines, self.fileURL, self.vendor]
+        return print_rows
+
     def merge_scan_item(self, other):
         """
         Merge two ScanItem instance into one.
-
-        TODO: define how to merge comments and implement.
         """
+        if sorted(self.licenses) != sorted(other.licenses):
+            self.license_reference = f"(Scancode) {', '.join(self.licenses)} / (Scanoss)  {', '.join(other.licenses)}"
+
         self.licenses = list(set(self.licenses + other.licenses))
 
         if len(self.copyright) > 0:

--- a/src/fosslight_source/cli.py
+++ b/src/fosslight_source/cli.py
@@ -25,6 +25,11 @@ SCANOSS_HEADER = {SCANOSS_SHEET_NAME: ['ID', 'Source Name or Path', 'OSS Name',
                                        'Homepage', 'Copyright Text', 'Exclude',
                                        'Comment', 'scanoss_matched_lines',
                                        'scanoss_fileURL', 'scanoss_vendor']}
+MERGED_HEADER = {SCANOSS_SHEET_NAME: ['ID', 'Source Name or Path', 'OSS Name',
+                                      'OSS Version', 'License', 'Download Location',
+                                      'Homepage', 'Copyright Text', 'Exclude',
+                                      'Comment', 'license_reference', 'scanoss_matched_lines',
+                                      'scanoss_fileURL', 'scanoss_vendor']}
 
 logger = logging.getLogger(constant.LOGGER_NAME)
 warnings.filterwarnings("ignore", category=FutureWarning)
@@ -126,9 +131,13 @@ def create_report_file(start_time, scanned_result, license_list, selected_scanne
     if selected_scanner == 'scancode' or output_extension == _json_ext:
         sheet_list[SCANOSS_SHEET_NAME] = [scan_item.get_row_to_print() for scan_item in scanned_result]
 
-    else:
+    elif selected_scanner == 'scanoss':
         sheet_list[SCANOSS_SHEET_NAME] = [scan_item.get_row_to_print_for_scanoss() for scan_item in scanned_result]
         extended_header = SCANOSS_HEADER
+
+    else:
+        sheet_list[SCANOSS_SHEET_NAME] = [scan_item.get_row_to_print_for_all_scanner() for scan_item in scanned_result]
+        extended_header = MERGED_HEADER
 
     if need_license:
         sheet_list["matched_text"] = get_license_list_to_print(license_list)

--- a/src/fosslight_source/run_scanoss.py
+++ b/src/fosslight_source/run_scanoss.py
@@ -39,6 +39,7 @@ def run_scanoss_py(path_to_scan, output_file_name="", format="", called_by_cli=F
         pkg_resources.get_distribution("scanoss")
     except Exception as error:
         logger.warning(str(error) + ". Skipping scan with scanoss.")
+        logger.warning("Please install scanoss and dataclasses before run fosslight_source with scanoss option.")
         return scanoss_file_list
     scan_command = "scanoss-py scan -o "
 


### PR DESCRIPTION
## Description
<!--
Please describe what this PR do.
 -->
Add "license_reference" column for excel output.

If both ScanCode and SCANOSS are run and;
if license findings from the scanners differ;
"license_reference" column will be filled with scanner name and scanned licenses respectively.

## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

