### PR TITLE
Change the scanoss-related packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,8 @@ if __name__ == "__main__":
                      "Programming Language :: Python :: 3.8",
                      "Programming Language :: Python :: 3.9", ],
         install_requires=required,
-        extras_require={":python_version>'3.6'": ["scanoss>=0.7.0"]},
+        extras_require={":python_version>'3.6'": ["scanoss>=0.7.0"],
+                        ":python_version<'3.7'": ["dataclasses", "scanoss"]},
         entry_points={
             "console_scripts": [
                 "fosslight_convert = fosslight_source.convert_scancode:main",


### PR DESCRIPTION
## Description
<!--
Please describe what this PR do.
 -->
When installing scanoss in python 3.6,
dataclasses need to be installed additionally.

## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

