### PR TITLE
Fix errors that occur in Python 3.6.7 or lower

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+pyparsing<=3.0.4;python_full_version<"3.6.8"
 scancode-toolkit
 typecode_libmagic
 XlsxWriter


### PR DESCRIPTION
## Description
<!--
Please describe what this PR do.
 -->
Fix errors that occur in Python 3.6.7 or lower. 
- From version 3.0.6 of pyparsing (version conflict issue occurs when installing version 3.0.5), only Python 3.6.8+ is supported.
Therefore, in the case of Python 3.6.7 or earlier, modify pyparsing to install 3.0.4 or earlier.

## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

