### PR TITLE
Move SCANOSS info to a separate sheet using -m option

### DIFF
--- a/src/fosslight_source/_parsing_scanoss_file.py
+++ b/src/fosslight_source/_parsing_scanoss_file.py
@@ -9,6 +9,18 @@ from ._scan_item import ScanItem
 from ._scan_item import is_exclude_file
 
 logger = logging.getLogger(constant.LOGGER_NAME)
+SCANOSS_INFO_HEADER = ['No', 'Source Name or Path', 'Component Declared', 'SPDX Tag',
+                       'File Header', 'License File', 'Scancode',
+                       'scanoss_matched_lines', 'scanoss_fileURL']
+
+
+def parsing_extraInfo(scanned_result):
+    scanoss_extra_info = []
+    for scan_item in scanned_result:
+        extra_item = scan_item.get_extra_info_row_for_scanoss()
+        scanoss_extra_info.append(extra_item)
+    scanoss_extra_info.insert(0, SCANOSS_INFO_HEADER)
+    return scanoss_extra_info
 
 
 def parsing_scanResult(scanoss_report):
@@ -28,12 +40,17 @@ def parsing_scanResult(scanoss_report):
             result_item.set_download_location(findings[0]['url'])
 
         license_detected = []
+        license_w_source = {}
         copyright_detected = []
         if 'licenses' in findings[0]:
             for license in findings[0]['licenses']:
                 license_detected.append(license['name'].lower())
+                if license['source'] not in license_w_source:
+                    license_w_source[license['source']] = []
+                license_w_source[license['source']].append(license['name'])
             if len(license_detected) > 0:
                 result_item.set_licenses(license_detected)
+                result_item.set_license_w_source(license_w_source)
         if 'copyrights' in findings[0]:
             for copyright in findings[0]['copyrights']:
                 copyright_detected.append(copyright['name'])

--- a/src/fosslight_source/_scan_item.py
+++ b/src/fosslight_source/_scan_item.py
@@ -23,6 +23,7 @@ _exclude_directory.append("/.")
 class ScanItem:
     file = ""
     licenses = []
+    license_w_source = {}
     copyright = ""
     exclude = False
     is_license_text = False
@@ -61,6 +62,9 @@ class ScanItem:
         if len(self.licenses) > 0:
             self.licenses = list(set(self.licenses))
 
+    def set_license_w_source(self, value):
+        self.license_w_source = value
+
     def set_exclude(self, value):
         self.exclude = value
 
@@ -98,16 +102,40 @@ class ScanItem:
     def get_row_to_print_for_scanoss(self):
         print_rows = [self.file, self.oss_name, self.oss_version, ','.join(self.licenses), self.download_location, "",
                       ','.join(self.copyright),
-                      "Exclude" if self.exclude else "",
-                      self.comment, self.matched_lines, self.fileURL, self.vendor]
+                      "Exclude" if self.exclude else "", self.comment]
         return print_rows
 
     def get_row_to_print_for_all_scanner(self):
         print_rows = [self.file, self.oss_name, self.oss_version, ','.join(self.licenses), self.download_location, "",
                       ','.join(self.copyright),
-                      "Exclude" if self.exclude else "",
-                      self.comment, self.license_reference, self.matched_lines, self.fileURL, self.vendor]
+                      "Exclude" if self.exclude else "", self.comment, self.license_reference]
         return print_rows
+
+    def get_extra_info_row_for_scanoss(self):
+        if 'component_declared' not in self.license_w_source.keys():
+            self.license_w_source['component_declared'] = ''
+        else:
+            self.license_w_source['component_declared'] = ','.join(self.license_w_source['component_declared'])
+        if 'file_spdx_tag' not in self.license_w_source.keys():
+            self.license_w_source['file_spdx_tag'] = ''
+        else:
+            self.license_w_source['file_spdx_tag'] = ','.join(self.license_w_source['file_spdx_tag'])
+        if 'file_header' not in self.license_w_source.keys():
+            self.license_w_source['file_header'] = ''
+        else:
+            self.license_w_source['file_header'] = ','.join(self.license_w_source['file_header'])
+        if 'license_file' not in self.license_w_source.keys():
+            self.license_w_source['license_file'] = ''
+        else:
+            self.license_w_source['license_file'] = ','.join(self.license_w_source['license_file'])
+        if 'scancode' not in self.license_w_source.keys():
+            self.license_w_source['scancode'] = ''
+        else:
+            self.license_w_source['scancode'] = ','.join(self.license_w_source['scancode'])
+        extra_info_rows = [self.file, self.license_w_source['component_declared'], self.license_w_source['file_spdx_tag'],
+                           self.license_w_source['file_header'], self.license_w_source['license_file'],
+                           self.license_w_source['scancode'], self.matched_lines, self.fileURL]
+        return extra_info_rows
 
     def merge_scan_item(self, other):
         """
@@ -138,6 +166,8 @@ class ScanItem:
             self.fileURL = other.fileURL
         if not self.vendor:
             self.vendor = other.vendor
+        if not self.license_w_source:
+            self.license_w_source = other.license_w_source
 
     def __eq__(self, other):
         return self.file == other.file

--- a/src/fosslight_source/cli.py
+++ b/src/fosslight_source/cli.py
@@ -18,18 +18,21 @@ from ._license_matched import get_license_list_to_print
 from fosslight_util.output_format import check_output_format, write_output_file
 from .run_scancode import run_scan
 from .run_scanoss import run_scanoss_py
+from .run_scanoss import get_scanoss_extra_info
 
 SCANOSS_SHEET_NAME = 'SRC_FL_Source'
 SCANOSS_HEADER = {SCANOSS_SHEET_NAME: ['ID', 'Source Name or Path', 'OSS Name',
                                        'OSS Version', 'License', 'Download Location',
                                        'Homepage', 'Copyright Text', 'Exclude',
-                                       'Comment', 'scanoss_matched_lines',
-                                       'scanoss_fileURL', 'scanoss_vendor']}
+                                       'Comment']}
 MERGED_HEADER = {SCANOSS_SHEET_NAME: ['ID', 'Source Name or Path', 'OSS Name',
                                       'OSS Version', 'License', 'Download Location',
                                       'Homepage', 'Copyright Text', 'Exclude',
-                                      'Comment', 'license_reference', 'scanoss_matched_lines',
-                                      'scanoss_fileURL', 'scanoss_vendor']}
+                                      'Comment', 'license_reference']}
+"""SCANOSS_INFO_HEADER = {"scancode_matched_text": ['No', 'Source Name or Path', 'Component Declared',
+                                                 'SPDX Tag', 'File Header', 'License File',
+                                                 'Scancode', 'scanoss_matched_lines',
+                                                 'scanoss_fileURL']}"""
 
 logger = logging.getLogger(constant.LOGGER_NAME)
 warnings.filterwarnings("ignore", category=FutureWarning)
@@ -142,7 +145,13 @@ def create_report_file(start_time, scanned_result, license_list, selected_scanne
         extended_header = MERGED_HEADER
 
     if need_license:
-        sheet_list["matched_text"] = get_license_list_to_print(license_list)
+        if selected_scanner == 'scancode' or output_extension == _json_ext:
+            sheet_list["scancode_matched_text"] = get_license_list_to_print(license_list)
+        elif selected_scanner == 'scanoss':
+            sheet_list["scanoss_reference"] = get_scanoss_extra_info(scanned_result)
+        else:
+            sheet_list["scancode_matched_text"] = get_license_list_to_print(license_list)
+            sheet_list["scanoss_reference"] = get_scanoss_extra_info(scanned_result)
 
     output_file_without_ext = os.path.join(output_path, output_file)
     success_to_write, writing_msg, result_file = write_output_file(output_file_without_ext, output_extension,

--- a/src/fosslight_source/run_scancode.py
+++ b/src/fosslight_source/run_scancode.py
@@ -16,7 +16,7 @@ from fosslight_util.set_log import init_log
 from ._parsing_scancode_file_item import parsing_file_item
 from ._parsing_scancode_file_item import get_error_from_header
 from ._help import print_help_msg_source
-from fosslight_util.output_format import check_output_format, write_output_file
+from fosslight_util.output_format import check_output_format
 
 logger = logging.getLogger(constant.LOGGER_NAME)
 warnings.filterwarnings("ignore", category=FutureWarning)
@@ -100,15 +100,6 @@ def run_scan(path_to_scan, output_file_name="",
                             result_list = sorted(
                                 result_list, key=lambda row: (''.join(row.licenses)))
                             sheet_list["SRC_FL_Source"] = [scan_item.get_row_to_print() for scan_item in result_list]
-
-                            output_file_without_ext = os.path.join(output_path, output_file)
-                            if not called_by_cli:
-                                success_to_write, writing_msg, result_file = write_output_file(output_file_without_ext,
-                                                                                               output_extension, sheet_list)
-                                if success_to_write:
-                                    logger.info(f"Writing Output file({result_file}, success:{success_to_write}")
-                                else:
-                                    logger.error(f"Fail to generate result file. msg:({writing_msg})")
 
             except Exception as ex:
                 success = False

--- a/src/fosslight_source/run_scancode.py
+++ b/src/fosslight_source/run_scancode.py
@@ -16,7 +16,6 @@ from fosslight_util.set_log import init_log
 from ._parsing_scancode_file_item import parsing_file_item
 from ._parsing_scancode_file_item import get_error_from_header
 from ._help import print_help_msg_source
-from ._license_matched import get_license_list_to_print
 from fosslight_util.output_format import check_output_format, write_output_file
 
 logger = logging.getLogger(constant.LOGGER_NAME)
@@ -101,8 +100,6 @@ def run_scan(path_to_scan, output_file_name="",
                             result_list = sorted(
                                 result_list, key=lambda row: (''.join(row.licenses)))
                             sheet_list["SRC_FL_Source"] = [scan_item.get_row_to_print() for scan_item in result_list]
-                            if need_license:
-                                sheet_list["matched_text"] = get_license_list_to_print(license_list)
 
                             output_file_without_ext = os.path.join(output_path, output_file)
                             if not called_by_cli:

--- a/src/fosslight_source/run_scanoss.py
+++ b/src/fosslight_source/run_scanoss.py
@@ -13,11 +13,16 @@ import fosslight_util.constant as constant
 from fosslight_util.set_log import init_log
 from fosslight_util.output_format import check_output_format  # , write_output_file
 from ._parsing_scanoss_file import parsing_scanResult  # scanoss
+from ._parsing_scanoss_file import parsing_extraInfo  # scanoss
 # from ._help import print_help_msg_source
 
 logger = logging.getLogger(constant.LOGGER_NAME)
 warnings.filterwarnings("ignore", category=FutureWarning)
 _PKG_NAME = "fosslight_source"
+
+
+def get_scanoss_extra_info(scanned_result):
+    return parsing_extraInfo(scanned_result)
 
 
 def run_scanoss_py(path_to_scan, output_file_name="", format="", called_by_cli=False, write_json_file=False, num_threads=-1):


### PR DESCRIPTION
## Description

- Moving SCANOSS reference information from main sheet to a separate sheet that is created with -m option. Before this PR is applied to the next release, we should discuss about the columns of the sheet and finalize the spec.
- Removing redundant output files cause by run_scancode while called as library.

Example of the output File

- SRC_FL_Source sheet
![image](https://user-images.githubusercontent.com/33045921/162863985-474520f7-ea6a-4e3a-8f55-f44d671811c7.png)
- scancode_matched_text sheet
![image](https://user-images.githubusercontent.com/33045921/162864147-4934a412-07a3-4bfe-8220-254f639f9150.png)
- scanoss_reference sheet
![image](https://user-images.githubusercontent.com/33045921/162864084-f43f897d-ac55-4877-9851-05a9a92c446e.png)

## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

