### PR TITLE
Add Dockerfile to build on ubuntu

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+# Copyright (c) 2021 LG Electronics Inc.
+# SPDX-License-Identifier: Apache-2.0
+FROM	ubuntu:20.04
+
+RUN 	apt-get update && apt-get install sudo -y
+RUN	ln -sf /bin/bash /bin/sh
+
+COPY	. /app
+WORKDIR	/app
+
+ENV 	DEBIAN_FRONTEND=noninteractive
+
+RUN	apt-get -y install build-essential
+RUN     apt-get -y install python3 python3-distutils python3-pip python3-dev
+RUN	apt-get -y install python3-intbitset python3-magic
+RUN	apt-get -y install libxml2-dev
+RUN	apt-get -y install libxslt1-dev
+RUN 	apt-get -y install libhdf5-dev
+RUN 	apt-get -y install bzip2 xz-utils zlib1g libpopt0 
+RUN	apt-get -y install gcc-10 g++-10
+RUN	pip3 install --upgrade pip
+RUN	pip3 install .
+RUN	pip3 install dparse
+
+ENTRYPOINT ["/usr/local/bin/fosslight_source"] 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 pyparsing<=3.0.4;python_full_version<"3.6.8"
 scancode-toolkit
-typecode_libmagic
 XlsxWriter
+typecode-libmagic-from-sources
 fosslight_util>=1.3.12
 PyYAML
 wheel


### PR DESCRIPTION
## Description
<!--
Please describe what this PR do.
 -->
Provide a Dockerfile to run fosslight_source in an unsupported OS environment such as mac m1.
How to run:
```
$docker build -t fosslight .
$docker run -it -v /Users/soim/git/fosslight_source_scanner/test_output:/app/output fosslight -p tests/test_files -o output
```

## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

