### PR TITLE
Print SCANOSS info in a separate sheet

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+# Copyright (c) 2021 LG Electronics Inc.
+# SPDX-License-Identifier: Apache-2.0
+FROM	ubuntu:20.04
+
+RUN 	apt-get update && apt-get install sudo -y
+RUN	ln -sf /bin/bash /bin/sh
+
+COPY	. /app
+WORKDIR	/app
+
+ENV 	DEBIAN_FRONTEND=noninteractive
+
+RUN	apt-get -y install build-essential
+RUN     apt-get -y install python3 python3-distutils python3-pip python3-dev
+RUN	apt-get -y install python3-intbitset python3-magic
+RUN	apt-get -y install libxml2-dev
+RUN	apt-get -y install libxslt1-dev
+RUN 	apt-get -y install libhdf5-dev
+RUN 	apt-get -y install bzip2 xz-utils zlib1g libpopt0 
+RUN	apt-get -y install gcc-10 g++-10
+RUN	pip3 install --upgrade pip
+RUN	pip3 install .
+RUN	pip3 install dparse
+
+ENTRYPOINT ["/usr/local/bin/fosslight_source"] 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 pyparsing<=3.0.4;python_full_version<"3.6.8"
 scancode-toolkit
-typecode_libmagic
 XlsxWriter
+typecode-libmagic-from-sources
 fosslight_util>=1.3.12
 PyYAML
 wheel

--- a/src/fosslight_source/_parsing_scancode_file_item.py
+++ b/src/fosslight_source/_parsing_scancode_file_item.py
@@ -74,12 +74,12 @@ def parsing_file_item(scancode_file_list, has_error, need_matched_license=False)
                     error_msg = file["scan_errors"]
                     if len(error_msg) > 0:
                         logger.debug(f"Test_msg {file_path}:{error_msg}")
-                        result_item.set_comment(",".join(error_msg))
+                        result_item.comment = ",".join(error_msg)
                         scancode_file_item.append(result_item)
                         continue
 
                 copyright_value_list = [x["value"] for x in copyright_list]
-                result_item.set_copyright(copyright_value_list)
+                result_item.copyright = copyright_value_list
 
                 # Set the license value
                 license_detected = []
@@ -137,19 +137,18 @@ def parsing_file_item(scancode_file_list, has_error, need_matched_license=False)
 
                     matched_rule = lic_item["matched_rule"]
                     if matched_rule["is_license_text"]:
-                        result_item.set_is_license_text(True)
+                        result_item.is_license_text = True
 
                 if len(license_detected) > 0:
-                    result_item.set_licenses(license_detected)
+                    result_item.licenses = license_detected
 
                     if len(license_expression_list) > 0:
                         license_expression_list = list(
                             set(license_expression_list))
-                        result_item.set_comment(
-                            ','.join(license_expression_list))
+                        result_item.comment = ','.join(license_expression_list)
 
                     if is_exclude_file(file_path, prev_dir, prev_dir_value):
-                        result_item.set_exclude(True)
+                        result_item.exclude = True
                     scancode_file_item.append(result_item)
 
         except Exception as ex:

--- a/src/fosslight_source/_parsing_scanoss_file.py
+++ b/src/fosslight_source/_parsing_scanoss_file.py
@@ -9,6 +9,46 @@ from ._scan_item import ScanItem
 from ._scan_item import is_exclude_file
 
 logger = logging.getLogger(constant.LOGGER_NAME)
+SCANOSS_INFO_HEADER = ['No', 'Source Name or Path', 'Component Declared', 'SPDX Tag',
+                       'File Header', 'License File', 'Scancode',
+                       'scanoss_matched_lines', 'scanoss_fileURL']
+
+
+def parsing_extraInfo(scanned_result):
+    scanoss_extra_info = []
+    for scan_item in scanned_result:
+        license_w_source = scan_item.scanoss_reference
+        if license_w_source:
+            license_w_source = refine_license_source_output(license_w_source)
+            extra_item = [scan_item.file, license_w_source['component_declared'], license_w_source['file_spdx_tag'],
+                          license_w_source['file_header'], license_w_source['license_file'], license_w_source['scancode'],
+                          scan_item.matched_lines, scan_item.fileURL]
+            scanoss_extra_info.append(extra_item)
+    scanoss_extra_info.insert(0, SCANOSS_INFO_HEADER)
+    return scanoss_extra_info
+
+
+def refine_license_source_input(license_w_source):
+    if 'component_declared' not in license_w_source.keys():
+        license_w_source['component_declared'] = ''
+    if 'file_spdx_tag' not in license_w_source.keys():
+        license_w_source['file_spdx_tag'] = ''
+    if 'file_header' not in license_w_source.keys():
+        license_w_source['file_header'] = ''
+    if 'license_file' not in license_w_source.keys():
+        license_w_source['license_file'] = ''
+    if 'scancode' not in license_w_source.keys():
+        license_w_source['scancode'] = ''
+    return license_w_source
+
+
+def refine_license_source_output(license_w_source):
+    license_w_source['component_declared'] = ','.join(license_w_source['component_declared'])
+    license_w_source['file_spdx_tag'] = ','.join(license_w_source['file_spdx_tag'])
+    license_w_source['file_header'] = ','.join(license_w_source['file_header'])
+    license_w_source['license_file'] = ','.join(license_w_source['license_file'])
+    license_w_source['scancode'] = ','.join(license_w_source['scancode'])
+    return license_w_source
 
 
 def parsing_scanResult(scanoss_report):
@@ -21,39 +61,42 @@ def parsing_scanResult(scanoss_report):
                 continue
 
         if 'component' in findings[0]:
-            result_item.set_oss_name(findings[0]['component'])
+            result_item.oss_name = findings[0]['component']
         if 'version' in findings[0]:
-            result_item.set_oss_version(findings[0]['version'])
+            result_item.oss_version = findings[0]['version']
         if 'url' in findings[0]:
-            result_item.set_download_location(findings[0]['url'])
+            result_item.download_location = findings[0]['url']
 
         license_detected = []
+        license_w_source = {}
         copyright_detected = []
         if 'licenses' in findings[0]:
             for license in findings[0]['licenses']:
                 license_detected.append(license['name'].lower())
+                if license['source'] not in license_w_source:
+                    license_w_source[license['source']] = []
+                license_w_source[license['source']].append(license['name'])
             if len(license_detected) > 0:
-                result_item.set_licenses(license_detected)
+                result_item.licenses = license_detected
+                result_item.scanoss_reference = refine_license_source_input(license_w_source)
         if 'copyrights' in findings[0]:
             for copyright in findings[0]['copyrights']:
                 copyright_detected.append(copyright['name'])
             if len(copyright_detected) > 0:
-                result_item.set_copyright(copyright_detected)
+                result_item.copyright = copyright_detected
 
         if is_exclude_file(file_path):
-            result_item.set_exclude(True)
+            result_item.exclude = True
 
-        if 'vendor' in findings[0]:
-            result_item.set_vendor(findings[0]['vendor'])
         if 'file_url' in findings[0]:
-            result_item.set_fileURL(findings[0]['file_url'])
+            result_item.fileURL = findings[0]['file_url']
         if 'matched' in findings[0]:
             if 'lines' in findings[0]:
-                result_item.set_matched_lines(f"{findings[0]['matched']} ({findings[0]['lines']})")
+                result_item.matched_lines = f"{findings[0]['matched']} ({findings[0]['lines']})"
             else:
-                result_item.set_matched_lines(f"{findings[0]['matched']}")
+                result_item.matched_lines = f"{findings[0]['matched']}"
         elif 'lines' in findings[0]:
-            result_item.set_matched_lines(f"({findings[0]['lines']})")
+            result_item.matched_lines = f"({findings[0]['lines']})"
 
         scanoss_file_item.append(result_item)
 

--- a/src/fosslight_source/_scan_item.py
+++ b/src/fosslight_source/_scan_item.py
@@ -22,8 +22,7 @@ _exclude_directory.append("/.")
 
 class ScanItem:
     file = ""
-    licenses = []
-    copyright = ""
+    scanoss_reference = {}
     exclude = False
     is_license_text = False
     oss_name = ""
@@ -31,13 +30,12 @@ class ScanItem:
     download_location = ""
     matched_lines = ""
     fileURL = ""
-    vendor = ""
     license_reference = ""
 
     def __init__(self, value):
         self.file = value
-        self.copyright = []
-        self.licenses = []
+        self._copyright = []
+        self._licenses = []
         self.comment = ""
         self.exclude = False
         self.is_license_text = False
@@ -45,48 +43,25 @@ class ScanItem:
     def __del__(self):
         pass
 
-    def set_comment(self, value):
-        self.comment = value
+    @property
+    def copyright(self):
+        return self._copyright
 
-    def set_file(self, value):
-        self.file = value
+    @copyright.setter
+    def copyright(self, value):
+        self._copyright.extend(value)
+        if len(self._copyright) > 0:
+            self._copyright = list(set(self._copyright))
 
-    def set_copyright(self, value):
-        self.copyright.extend(value)
-        if len(self.copyright) > 0:
-            self.copyright = list(set(self.copyright))
+    @property
+    def licenses(self):
+        return self._licenses
 
-    def set_licenses(self, value):
-        self.licenses.extend(value)
-        if len(self.licenses) > 0:
-            self.licenses = list(set(self.licenses))
-
-    def set_exclude(self, value):
-        self.exclude = value
-
-    def set_is_license_text(self, value):
-        self.is_license_text = value
-
-    def set_oss_name(self, value):
-        self.oss_name = value
-
-    def set_oss_version(self, value):
-        self.oss_version = value
-
-    def set_download_location(self, value):
-        self.download_location = value
-
-    def set_matched_lines(self, value):
-        self.matched_lines = value
-
-    def set_fileURL(self, value):
-        self.fileURL = value
-
-    def set_vendor(self, value):
-        self.vendor = value
-
-    def set_license_reference(self, value):
-        self.license_reference = value
+    @licenses.setter
+    def licenses(self, value):
+        self._licenses.extend(value)
+        if len(self._licenses) > 0:
+            self._licenses = list(set(self._licenses))
 
     def get_row_to_print(self):
         print_rows = [self.file, self.oss_name, self.oss_version, ','.join(self.licenses), self.download_location, "",
@@ -98,15 +73,13 @@ class ScanItem:
     def get_row_to_print_for_scanoss(self):
         print_rows = [self.file, self.oss_name, self.oss_version, ','.join(self.licenses), self.download_location, "",
                       ','.join(self.copyright),
-                      "Exclude" if self.exclude else "",
-                      self.comment, self.matched_lines, self.fileURL, self.vendor]
+                      "Exclude" if self.exclude else "", self.comment]
         return print_rows
 
     def get_row_to_print_for_all_scanner(self):
         print_rows = [self.file, self.oss_name, self.oss_version, ','.join(self.licenses), self.download_location, "",
                       ','.join(self.copyright),
-                      "Exclude" if self.exclude else "",
-                      self.comment, self.license_reference, self.matched_lines, self.fileURL, self.vendor]
+                      "Exclude" if self.exclude else "", self.comment, self.license_reference]
         return print_rows
 
     def merge_scan_item(self, other):
@@ -136,8 +109,8 @@ class ScanItem:
             self.matched_lines = other.matched_lines
         if not self.fileURL:
             self.fileURL = other.fileURL
-        if not self.vendor:
-            self.vendor = other.vendor
+        if not self.scanoss_reference:
+            self.scanoss_reference = other.scanoss_reference
 
     def __eq__(self, other):
         return self.file == other.file

--- a/src/fosslight_source/cli.py
+++ b/src/fosslight_source/cli.py
@@ -154,7 +154,7 @@ def create_report_file(start_time, scanned_result, license_list, selected_scanne
 
 
 def run_all_scanners(path_to_scan, output_file_name="", _write_json_file=False, num_cores=-1,
-                     need_license=False, format="", called_by_cli=False):
+                     need_license=False, format="", called_by_cli=True):
     """
     Run Scancode and scanoss.py for the given path.
 

--- a/src/fosslight_source/cli.py
+++ b/src/fosslight_source/cli.py
@@ -18,18 +18,17 @@ from ._license_matched import get_license_list_to_print
 from fosslight_util.output_format import check_output_format, write_output_file
 from .run_scancode import run_scan
 from .run_scanoss import run_scanoss_py
+from .run_scanoss import get_scanoss_extra_info
 
 SCANOSS_SHEET_NAME = 'SRC_FL_Source'
 SCANOSS_HEADER = {SCANOSS_SHEET_NAME: ['ID', 'Source Name or Path', 'OSS Name',
                                        'OSS Version', 'License', 'Download Location',
                                        'Homepage', 'Copyright Text', 'Exclude',
-                                       'Comment', 'scanoss_matched_lines',
-                                       'scanoss_fileURL', 'scanoss_vendor']}
+                                       'Comment']}
 MERGED_HEADER = {SCANOSS_SHEET_NAME: ['ID', 'Source Name or Path', 'OSS Name',
                                       'OSS Version', 'License', 'Download Location',
                                       'Homepage', 'Copyright Text', 'Exclude',
-                                      'Comment', 'license_reference', 'scanoss_matched_lines',
-                                      'scanoss_fileURL', 'scanoss_vendor']}
+                                      'Comment', 'license_reference']}
 
 logger = logging.getLogger(constant.LOGGER_NAME)
 warnings.filterwarnings("ignore", category=FutureWarning)
@@ -142,7 +141,13 @@ def create_report_file(start_time, scanned_result, license_list, selected_scanne
         extended_header = MERGED_HEADER
 
     if need_license:
-        sheet_list["matched_text"] = get_license_list_to_print(license_list)
+        if selected_scanner == 'scancode' or output_extension == _json_ext:
+            sheet_list["scancode_reference"] = get_license_list_to_print(license_list)
+        elif selected_scanner == 'scanoss':
+            sheet_list["scanoss_reference"] = get_scanoss_extra_info(scanned_result)
+        else:
+            sheet_list["scancode_reference"] = get_license_list_to_print(license_list)
+            sheet_list["scanoss_reference"] = get_scanoss_extra_info(scanned_result)
 
     output_file_without_ext = os.path.join(output_path, output_file)
     success_to_write, writing_msg, result_file = write_output_file(output_file_without_ext, output_extension,

--- a/src/fosslight_source/run_scanoss.py
+++ b/src/fosslight_source/run_scanoss.py
@@ -13,6 +13,7 @@ import fosslight_util.constant as constant
 from fosslight_util.set_log import init_log
 from fosslight_util.output_format import check_output_format  # , write_output_file
 from ._parsing_scanoss_file import parsing_scanResult  # scanoss
+from ._parsing_scanoss_file import parsing_extraInfo  # scanoss
 import shutil
 from pathlib import Path
 
@@ -22,6 +23,10 @@ _PKG_NAME = "fosslight_source"
 SCANOSS_RESULT_FILE = "scanner_output.wfp"
 SCANOSS_OUTPUT_FILE = "scanoss_raw_result.json"
 SCANOSS_COMMAND_PREFIX = "scanoss-py scan -o "
+
+
+def get_scanoss_extra_info(scanned_result):
+    return parsing_extraInfo(scanned_result)
 
 
 def run_scanoss_py(path_to_scan, output_file_name="", format="", called_by_cli=False, write_json_file=False, num_threads=-1):

--- a/tox.ini
+++ b/tox.ini
@@ -26,24 +26,7 @@ deps =
 
 commands =
   rm -rf test_scan
-  fosslight_source -p tests/test_files -o test_scan/scan_result.csv -m
-  cat test_scan/scan_result.csv
-
-  fosslight_source -p tests/test_files -o test_scan/scan_result.csv -f csv
-  cat test_scan/scan_result.csv
-
-  fosslight_source -p tests/test_files -o test_scan/scan_result.json -f opossum
-  cat test_scan/scan_result.json
-
-  fosslight_source -p tests/test_files -o test_scan/scan_result.xlsx -f excel
-  ls test_scan/scan_result.xlsx
-
-  fosslight_source -p tests/test_files -j -o test_scan/
-  ls test_scan/scancode_raw_result.json
-  ls test_scan/scanoss_fingerprint.wfp
-  ls test_scan/scanoss_raw_result.json
-
-  python tests/cli_test.py
+  fosslight_source -p tests/test_files -j -m -o test_scan
 
 [testenv:release]
 deps =
@@ -52,22 +35,13 @@ deps =
 commands =
   fosslight_source -h
   fosslight_convert -h
-  fosslight_source -p tests/test_files -o test_scan/scan_result.csv -m
+
+  fosslight_source -p tests/test_files -o test_scan/scan_result.csv
   cat test_scan/scan_result.csv
 
-  fosslight_source -p tests/test_files -o test_scan/scan_result.csv -f csv
-  cat test_scan/scan_result.csv
+  fosslight_source -p tests/test_files -m -j -o test_scan2/
+  ls test_scan2/
 
-  fosslight_source -p tests/test_files -o test_scan/scan_result.json -f opossum
-  cat test_scan/scan_result.json
-
-  fosslight_source -p tests/test_files -o test_scan/scan_result.xlsx -f excel
-  ls test_scan/scan_result.xlsx
-
-  fosslight_source -p tests/test_files -j -o test_scan/
-  ls test_scan/scancode_raw_result.json
-  ls test_scan/scanoss_fingerprint.wfp
-  ls test_scan/scanoss_raw_result.json
   python tests/cli_test.py
   pytest -v --flake8
-  
+ 


### PR DESCRIPTION
## Description
- Moving SCANOSS reference information from main sheet to a separate sheet that is created with -m option. Before this PR is applied to the next release, we should discuss about the columns of the sheet and finalize the spec.
- Removing redundant output files cause by run_scancode while called as library.

Example of the output File

- SRC_FL_Source sheet
![image](https://user-images.githubusercontent.com/33045921/164168861-118d5d58-737c-4dad-9f7e-84817994494b.png)
- scancode_matched_text sheet
![image](https://user-images.githubusercontent.com/33045921/164168896-09be9967-7b48-41ee-9159-f1a955022a57.png)
- scanoss_reference sheet
![image](https://user-images.githubusercontent.com/33045921/164168924-64033c70-8ae8-4be4-9d1e-a4817e0eb68e.png)

## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

