### PR TITLE
Fix cli.py to remove redundant report

### DIFF
--- a/src/fosslight_source/cli.py
+++ b/src/fosslight_source/cli.py
@@ -154,7 +154,7 @@ def create_report_file(start_time, scanned_result, license_list, selected_scanne
 
 
 def run_all_scanners(path_to_scan, output_file_name="", _write_json_file=False, num_cores=-1,
-                     need_license=False, format="", called_by_cli=False):
+                     need_license=False, format="", called_by_cli=True):
     """
     Run Scancode and scanoss.py for the given path.
 

--- a/tox.ini
+++ b/tox.ini
@@ -26,24 +26,7 @@ deps =
 
 commands =
   rm -rf test_scan
-  fosslight_source -p tests/test_files -o test_scan/scan_result.csv -m
-  cat test_scan/scan_result.csv
-
-  fosslight_source -p tests/test_files -o test_scan/scan_result.csv -f csv
-  cat test_scan/scan_result.csv
-
-  fosslight_source -p tests/test_files -o test_scan/scan_result.json -f opossum
-  cat test_scan/scan_result.json
-
-  fosslight_source -p tests/test_files -o test_scan/scan_result.xlsx -f excel
-  ls test_scan/scan_result.xlsx
-
-  fosslight_source -p tests/test_files -j -o test_scan/
-  ls test_scan/scancode_raw_result.json
-  ls test_scan/scanoss_fingerprint.wfp
-  ls test_scan/scanoss_raw_result.json
-
-  python tests/cli_test.py
+  fosslight_source -p tests/test_files -j -m -o test_scan
 
 [testenv:release]
 deps =
@@ -52,22 +35,13 @@ deps =
 commands =
   fosslight_source -h
   fosslight_convert -h
-  fosslight_source -p tests/test_files -o test_scan/scan_result.csv -m
+
+  fosslight_source -p tests/test_files -o test_scan/scan_result.csv
   cat test_scan/scan_result.csv
 
-  fosslight_source -p tests/test_files -o test_scan/scan_result.csv -f csv
-  cat test_scan/scan_result.csv
+  fosslight_source -p tests/test_files -m -j -o test_scan2/
+  ls test_scan2/
 
-  fosslight_source -p tests/test_files -o test_scan/scan_result.json -f opossum
-  cat test_scan/scan_result.json
-
-  fosslight_source -p tests/test_files -o test_scan/scan_result.xlsx -f excel
-  ls test_scan/scan_result.xlsx
-
-  fosslight_source -p tests/test_files -j -o test_scan/
-  ls test_scan/scancode_raw_result.json
-  ls test_scan/scanoss_fingerprint.wfp
-  ls test_scan/scanoss_raw_result.json
   python tests/cli_test.py
   pytest -v --flake8
-  
+ 


### PR DESCRIPTION
## Description
<!--
Please describe what this PR do.
 -->
- Fix cli.py to remove redundant report.
    To fix the bug where the ScanCode result report is additionally generated, set the ScanCode Report not to be created separately by default.
- Fix the bug where ScanOSS output fails when the output directory does not exist.
- Make the tox command simple.

## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

