### PR TITLE
Amend how to handle path without files to scan for SCANOSS

### DIFF
--- a/src/fosslight_source/cli.py
+++ b/src/fosslight_source/cli.py
@@ -85,21 +85,26 @@ def main():
     logger, _result_log = init_log(os.path.join(output_path, "fosslight_src_log_"+start_time+".txt"),
                                    True, logging.INFO, logging.DEBUG, _PKG_NAME, path_to_scan)
 
-    if selected_scanner == 'scancode':
-        success, _result_log["Scan Result"], scanned_result, license_list = run_scan(path_to_scan, output_file_name,
-                                                                                     write_json_file, -1, True,
-                                                                                     print_matched_text, format, True)
-    elif selected_scanner == 'scanoss':
-        scanned_result = run_scanoss_py(path_to_scan, output_file_name, format, True, write_json_file)
-    elif selected_scanner == 'all' or selected_scanner == '':
-        success, _result_log["Scan Result"], scanned_result, license_list = run_all_scanners(path_to_scan, output_file_name,
-                                                                                             write_json_file, -1,
-                                                                                             print_matched_text, format, True)
+    if os.path.isdir(path_to_scan):
+
+        if selected_scanner == 'scancode':
+            success, _result_log["Scan Result"], scanned_result, license_list = run_scan(path_to_scan, output_file_name,
+                                                                                         write_json_file, -1, True,
+                                                                                         print_matched_text, format, True)
+        elif selected_scanner == 'scanoss':
+            scanned_result = run_scanoss_py(path_to_scan, output_file_name, format, True, write_json_file)
+        elif selected_scanner == 'all' or selected_scanner == '':
+            success, _result_log["Scan Result"], scanned_result, license_list = run_all_scanners(path_to_scan, output_file_name,
+                                                                                                 write_json_file, -1,
+                                                                                                 print_matched_text, format, True)
+        else:
+            print_help_msg_source()
+            sys.exit(1)
+        create_report_file(start_time, scanned_result, license_list, selected_scanner, print_matched_text,
+                           output_path, output_file, output_extension)
     else:
-        print_help_msg_source()
+        logger.error(f"Check the path to scan. : {path_to_scan}")
         sys.exit(1)
-    create_report_file(start_time, scanned_result, license_list, selected_scanner, print_matched_text,
-                       output_path, output_file, output_extension)
 
 
 def create_report_file(start_time, scanned_result, license_list, selected_scanner, need_license=False,

--- a/src/fosslight_source/run_scancode.py
+++ b/src/fosslight_source/run_scancode.py
@@ -6,7 +6,6 @@
 import os
 import multiprocessing
 import warnings
-import platform
 import logging
 import yaml
 from scancode import cli
@@ -15,7 +14,6 @@ import fosslight_util.constant as constant
 from fosslight_util.set_log import init_log
 from ._parsing_scancode_file_item import parsing_file_item
 from ._parsing_scancode_file_item import get_error_from_header
-from ._help import print_help_msg_source
 from ._license_matched import get_license_list_to_print
 from fosslight_util.output_format import check_output_format, write_output_file
 
@@ -37,7 +35,6 @@ def run_scan(path_to_scan, output_file_name="",
     license_list = []
     _json_ext = ".json"
 
-    _windows = platform.system() == "Windows"
     start_time = datetime.now().strftime('%Y%m%d_%H%M%S')
 
     success, msg, output_path, output_file, output_extension = check_output_format(output_file_name, format)
@@ -62,12 +59,6 @@ def run_scan(path_to_scan, output_file_name="",
         if not called_by_cli:
             logger, _result_log = init_log(os.path.join(output_path, f"fosslight_src_log_{start_time}.txt"),
                                            True, logging.INFO, logging.DEBUG, _PKG_NAME, path_to_scan)
-
-        if path_to_scan == "":
-            if _windows:
-                path_to_scan = os.getcwd()
-            else:
-                print_help_msg_source()
 
         num_cores = multiprocessing.cpu_count() - 1 if num_cores < 0 else num_cores
 

--- a/src/fosslight_source/run_scanoss.py
+++ b/src/fosslight_source/run_scanoss.py
@@ -16,6 +16,8 @@ from ._parsing_scanoss_file import parsing_scanResult  # scanoss
 from ._parsing_scanoss_file import parsing_extraInfo  # scanoss
 import shutil
 from pathlib import Path
+import platform
+from ._help import print_help_msg_source
 
 logger = logging.getLogger(constant.LOGGER_NAME)
 warnings.filterwarnings("ignore", category=FutureWarning)
@@ -41,11 +43,19 @@ def run_scanoss_py(path_to_scan, output_file_name="", format="", called_by_cli=F
     :return scanoss_file_list: list of ScanItem (scanned result by files).
     """
     success, msg, output_path, output_file, output_extension = check_output_format(output_file_name, format)
+    _windows = platform.system() == "Windows"
+
     if not called_by_cli:
         global logger
         start_time = datetime.now().strftime('%Y%m%d_%H%M%S')
         logger, _result_log = init_log(os.path.join(output_path, f"fosslight_src_log_{start_time}.txt"),
                                        True, logging.INFO, logging.DEBUG, _PKG_NAME, path_to_scan)
+
+    if path_to_scan == "":
+        if _windows:
+            path_to_scan = os.getcwd()
+        else:
+            print_help_msg_source()
 
     scanoss_file_list = []
     try:
@@ -76,7 +86,7 @@ def run_scanoss_py(path_to_scan, output_file_name="", format="", called_by_cli=F
                 st_python = json.load(st_json)
                 scanoss_file_list = parsing_scanResult(st_python)
     except Exception as error:
-        logger.warning(f"SCANOSS Parsing {path_to_scan}: {error}")
+        logger.debug(f"SCANOSS Parsing {path_to_scan}: {error}")
 
     logger.info(f"|---Number of files detected with SCANOSS: {(len(scanoss_file_list))}")
 

--- a/src/fosslight_source/run_scanoss.py
+++ b/src/fosslight_source/run_scanoss.py
@@ -16,8 +16,6 @@ from ._parsing_scanoss_file import parsing_scanResult  # scanoss
 from ._parsing_scanoss_file import parsing_extraInfo  # scanoss
 import shutil
 from pathlib import Path
-import platform
-from ._help import print_help_msg_source
 
 logger = logging.getLogger(constant.LOGGER_NAME)
 warnings.filterwarnings("ignore", category=FutureWarning)
@@ -43,19 +41,12 @@ def run_scanoss_py(path_to_scan, output_file_name="", format="", called_by_cli=F
     :return scanoss_file_list: list of ScanItem (scanned result by files).
     """
     success, msg, output_path, output_file, output_extension = check_output_format(output_file_name, format)
-    _windows = platform.system() == "Windows"
 
     if not called_by_cli:
         global logger
         start_time = datetime.now().strftime('%Y%m%d_%H%M%S')
         logger, _result_log = init_log(os.path.join(output_path, f"fosslight_src_log_{start_time}.txt"),
                                        True, logging.INFO, logging.DEBUG, _PKG_NAME, path_to_scan)
-
-    if path_to_scan == "":
-        if _windows:
-            path_to_scan = os.getcwd()
-        else:
-            print_help_msg_source()
 
     scanoss_file_list = []
     try:


### PR DESCRIPTION
## Description
- Handle path without files to scan when SCANOSS is on
- Handle path that doesn't exist when SCANOSS is on

## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

