### PR TITLE
Fix typecode-libmagic-from-sources installation bug

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 pyparsing<=3.0.4;python_full_version<"3.6.8"
 scancode-toolkit
 XlsxWriter
-typecode-libmagic-from-sources
+typecode-libmagic
 fosslight_util>=1.4.0
 PyYAML
 wheel


### PR DESCRIPTION
## Description
<!--
Please describe what this PR do.
 -->
Fix typecode-libmagic-from-sources installation bug.

```
note: This error originates from a subprocess, and is likely not a problem with pip.
error: legacy-install-failure

× Encountered error while trying to install package.
╰─> typecode-libmagic-from-sources
```

## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

