### PR TITLE
Fix package download bug during docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 FROM	ubuntu:20.04
 
+RUN     apt-get clean
 RUN 	apt-get update && apt-get install sudo -y
 RUN	ln -sf /bin/bash /bin/sh
 


### PR DESCRIPTION
## Description
<!--
Please describe what this PR do.
 -->
Fix the bug that the related package cannot be downloaded when installing with Docker.

## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

