### PR TITLE
Fix a bug when reading a non-existent key

### DIFF
--- a/src/fosslight_source/_parsing_scancode_file_item.py
+++ b/src/fosslight_source/_parsing_scancode_file_item.py
@@ -84,7 +84,7 @@ def parsing_file_item(scancode_file_list, has_error, need_matched_license=False)
                     if licenses is None or licenses == "":
                         continue
 
-                    license_expression_list = file.get("license_expressions",{})
+                    license_expression_list = file.get("license_expressions", {})
                     if len(license_expression_list) > 0:
                         license_expression_list = [
                             x.lower() for x in license_expression_list

--- a/src/fosslight_source/_parsing_scancode_file_item.py
+++ b/src/fosslight_source/_parsing_scancode_file_item.py
@@ -53,12 +53,9 @@ def parsing_file_item(scancode_file_list, has_error, need_matched_license=False)
     if scancode_file_list:
         for file in scancode_file_list:
             try:
-                is_binary = False
                 is_dir = False
-                file_path = file["path"]
-
-                if "is_binary" in file:
-                    is_binary = file["is_binary"]
+                file_path = file.get("path", "")
+                is_binary = file.get("is_binary", False)
                 if "type" in file:
                     is_dir = file["type"] == "directory"
                     if is_dir:
@@ -66,13 +63,13 @@ def parsing_file_item(scancode_file_list, has_error, need_matched_license=False)
                         prev_dir = file_path
 
                 if not is_binary and not is_dir:
-                    licenses = file["licenses"]
-                    copyright_list = file["copyrights"]
+                    licenses = file.get("licenses", [])
+                    copyright_list = file.get("copyrights", [])
 
                     result_item = ScanItem(file_path)
 
                     if has_error and "scan_errors" in file:
-                        error_msg = file["scan_errors"]
+                        error_msg = file.get("scan_errors", [])
                         if len(error_msg) > 0:
                             result_item.comment = ",".join(error_msg)
                             scancode_file_item.append(result_item)
@@ -95,8 +92,8 @@ def parsing_file_item(scancode_file_list, has_error, need_matched_license=False)
 
                     for lic_item in licenses:
                         license_value = ""
-                        key = lic_item["key"]
-                        spdx = lic_item["spdx_license_key"]
+                        key = lic_item.get("key", "")
+                        spdx = lic_item.get("spdx_license_key", "")
                         # logger.debug("LICENSE_KEY:"+str(key)+",SPDX:"+str(spdx))
 
                         if key is not None and key != "":
@@ -111,11 +108,10 @@ def parsing_file_item(scancode_file_list, has_error, need_matched_license=False)
                         if license_value != "":
                             if key == "unknown-spdx":
                                 try:
-                                    if "matched_text" in lic_item:
-                                        matched_txt = lic_item["matched_text"].lower()
-                                        matched = regex.search(matched_txt)
-                                        if matched:
-                                            license_value = str(matched.group())
+                                    matched_txt = lic_item.get("matched_text", "").lower()
+                                    matched = regex.search(matched_txt)
+                                    if matched:
+                                        license_value = str(matched.group())
                                 except Exception:
                                     pass
 
@@ -136,9 +132,8 @@ def parsing_file_item(scancode_file_list, has_error, need_matched_license=False)
                                         lic_info = MatchedLicense(license_value, lic_category, lic_matched_text, file_path)
                                         license_list[lic_matched_key] = lic_info
 
-                        matched_rule = lic_item["matched_rule"]
-                        if matched_rule["is_license_text"]:
-                            result_item.is_license_text = True
+                        matched_rule = lic_item.get("matched_rule", {})
+                        result_item.is_license_text = matched_rule.get("is_license_text", False)
 
                     if len(license_detected) > 0:
                         result_item.licenses = license_detected

--- a/src/fosslight_source/_parsing_scancode_file_item.py
+++ b/src/fosslight_source/_parsing_scancode_file_item.py
@@ -48,7 +48,7 @@ def parsing_file_item(scancode_file_list, has_error, need_matched_license=False)
 
     prev_dir = ""
     prev_dir_value = False
-    regex = re.compile(r'licenseref-(\S)+')
+    regex = re.compile(r'.*licenseref-(\S+)', re.IGNORECASE)
 
     if scancode_file_list:
         for file in scancode_file_list:
@@ -108,10 +108,10 @@ def parsing_file_item(scancode_file_list, has_error, need_matched_license=False)
                         if license_value != "":
                             if key == "unknown-spdx":
                                 try:
-                                    matched_txt = lic_item.get("matched_text", "").lower()
+                                    matched_txt = lic_item.get("matched_text", "")
                                     matched = regex.search(matched_txt)
                                     if matched:
-                                        license_value = str(matched.group())
+                                        license_value = str(matched.group(1))
                                 except Exception:
                                     pass
 

--- a/src/fosslight_source/_parsing_scancode_file_item.py
+++ b/src/fosslight_source/_parsing_scancode_file_item.py
@@ -55,6 +55,8 @@ def parsing_file_item(scancode_file_list, has_error, need_matched_license=False)
             try:
                 is_dir = False
                 file_path = file.get("path", "")
+                if not file_path:
+                    continue
                 is_binary = file.get("is_binary", False)
                 if "type" in file:
                     is_dir = file["type"] == "directory"

--- a/src/fosslight_source/_parsing_scancode_file_item.py
+++ b/src/fosslight_source/_parsing_scancode_file_item.py
@@ -44,7 +44,7 @@ def parsing_file_item(scancode_file_list, has_error, need_matched_license=False)
     rc = True
     scancode_file_item = []
     license_list = {}  # Key :[license]+[matched_text], value: MatchedLicense()
-    msg = ""
+    msg = []
 
     prev_dir = ""
     prev_dir_value = False
@@ -74,12 +74,12 @@ def parsing_file_item(scancode_file_list, has_error, need_matched_license=False)
                     if has_error and "scan_errors" in file:
                         error_msg = file["scan_errors"]
                         if len(error_msg) > 0:
-                            logger.debug(f"Test_msg {file_path}:{error_msg}")
                             result_item.comment = ",".join(error_msg)
                             scancode_file_item.append(result_item)
                             continue
-
-                    copyright_value_list = [x["value"] for x in copyright_list]
+                    copyright_value_list = []
+                    for x in copyright_list:
+                        copyright_value_list.append(x.get("value", ""))
                     result_item.copyright = copyright_value_list
 
                     # Set the license value
@@ -87,7 +87,7 @@ def parsing_file_item(scancode_file_list, has_error, need_matched_license=False)
                     if licenses is None or licenses == "":
                         continue
 
-                    license_expression_list = file["license_expressions"]
+                    license_expression_list = file.get("license_expressions",{})
                     if len(license_expression_list) > 0:
                         license_expression_list = [
                             x.lower() for x in license_expression_list
@@ -153,8 +153,7 @@ def parsing_file_item(scancode_file_list, has_error, need_matched_license=False)
                         scancode_file_item.append(result_item)
 
             except Exception as ex:
-                msg = f"* Error Parsing item: {ex}"
+                msg.append(f"Error Parsing item: {ex}")
                 rc = False
-                logger.debug(msg)
-
-    return rc, scancode_file_item, msg.strip(), license_list
+    msg = list(set(msg))
+    return rc, scancode_file_item, msg, license_list

--- a/src/fosslight_source/_parsing_scancode_file_item.py
+++ b/src/fosslight_source/_parsing_scancode_file_item.py
@@ -48,7 +48,7 @@ def parsing_file_item(scancode_file_list, has_error, need_matched_license=False)
 
     prev_dir = ""
     prev_dir_value = False
-    regex = re.compile(r'.*licenseref-(\S+)', re.IGNORECASE)
+    regex = re.compile(r'licenseref-(\S+)', re.IGNORECASE)
 
     if scancode_file_list:
         for file in scancode_file_list:
@@ -111,7 +111,7 @@ def parsing_file_item(scancode_file_list, has_error, need_matched_license=False)
                                     matched_txt = lic_item.get("matched_text", "")
                                     matched = regex.search(matched_txt)
                                     if matched:
-                                        license_value = str(matched.group(1))
+                                        license_value = str(matched.group())
                                 except Exception:
                                     pass
 

--- a/tests/test_files/dual.txt
+++ b/tests/test_files/dual.txt
@@ -1,3 +1,5 @@
 # Copyright (c) 2020 LG Electronics Inc.
 # Copyright (c) 2021 LG Electronics Inc.
+# REUSE-IgnoreStart
 # SPDX-License-Identifier: GPL-2.0 or MIT
+# REUSE-IgnoreEnd

--- a/tests/test_files/dual.txt
+++ b/tests/test_files/dual.txt
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: GPL-2.0 or MIT

--- a/tests/test_files/dual.txt
+++ b/tests/test_files/dual.txt
@@ -1,1 +1,3 @@
+# Copyright (c) 2020 LG Electronics Inc.
+# Copyright (c) 2021 LG Electronics Inc.
 # SPDX-License-Identifier: GPL-2.0 or MIT

--- a/tests/test_files/spdx_lic.txt
+++ b/tests/test_files/spdx_lic.txt
@@ -1,1 +1,3 @@
+# REUSE-IgnoreStart
 # SPDX-License-Identifier: licenseref-TEMP_LICENSE
+# REUSE-IgnoreEnd

--- a/tests/test_files/spdx_lic.txt
+++ b/tests/test_files/spdx_lic.txt
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: licenseref-TEMP_LICENSE


### PR DESCRIPTION
## Description
<!--
Please describe what this PR do.
 -->
- Fix a bug when loading a key that does not exist when parsing by item in the scancode analysis result.

## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

