### PR TITLE
Remove the last dot from the result in scanoss license finding

### DIFF
--- a/src/fosslight_source/_parsing_scanoss_file.py
+++ b/src/fosslight_source/_parsing_scanoss_file.py
@@ -55,6 +55,8 @@ def parsing_scanResult(scanoss_report):
             for license in findings[0]['licenses']:
 
                 license_lower = license['name'].lower()
+                if license_lower.endswith('.'):
+                    license_lower = license_lower[:-1]
                 for word in replace_word:
                     if word in license_lower:
                         license_lower = license_lower.replace(word, "")


### PR DESCRIPTION
## Description
Remove the last dot from the result in scanoss license finding.

Example : Apache-2.0. -> Apache-2.0

## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

