### PR TITLE
Add parameter for Scancode cores

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ typecode-libmagic
 fosslight_util>=1.4.0
 PyYAML
 wheel
+packaging<=21.3

--- a/src/fosslight_source/cli.py
+++ b/src/fosslight_source/cli.py
@@ -51,6 +51,7 @@ def main():
     scanned_result = []
     license_list = []
     time_out = 120
+    core = -1
 
     parser = argparse.ArgumentParser(description='FOSSLight Source', prog='fosslight_source', add_help=False)
     parser.add_argument('-h', '--help', action='store_true', required=False)
@@ -62,6 +63,7 @@ def main():
     parser.add_argument('-f', '--format', nargs=1, type=str, required=False)
     parser.add_argument('-s', '--scanner', nargs=1, type=str, required=False, default='all')
     parser.add_argument('-t', '--timeout', type=int, required=False, default=120)
+    parser.add_argument('-c', '--cores', type=int, required=False, default=-1)
 
     args = parser.parse_args()
 
@@ -84,6 +86,7 @@ def main():
         selected_scanner = ''.join(args.scanner)
 
     time_out = args.timeout
+    core = args.cores
 
     timer = TimerThread()
     timer.setDaemon(True)
@@ -103,14 +106,14 @@ def main():
     if os.path.isdir(path_to_scan):
         if selected_scanner == 'scancode':
             success, _result_log["Scan Result"], scanned_result, license_list = run_scan(path_to_scan, output_file_name,
-                                                                                         write_json_file, -1, True,
+                                                                                         write_json_file, core, True,
                                                                                          print_matched_text, format, True,
                                                                                          time_out)
         elif selected_scanner == 'scanoss':
             scanned_result = run_scanoss_py(path_to_scan, output_file_name, format, True, write_json_file)
         elif selected_scanner == 'all' or selected_scanner == '':
             success, _result_log["Scan Result"], scanned_result, license_list = run_all_scanners(path_to_scan, output_file_name,
-                                                                                                 write_json_file, -1,
+                                                                                                 write_json_file, core,
                                                                                                  print_matched_text, format, True,
                                                                                                  time_out)
         else:

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ skipdist = true
 
 [testenv]
 install_command = pip install {opts} {packages}
-whitelist_externals = 
+allowlist_externals = 
   cat
   rm
   ls


### PR DESCRIPTION
## Description
<!--
Please describe what this PR do.
 -->
1. Execute Scancode with multi-processing as many as the number of input cores.
    - Default : Number of cores - 1
2. tox: Use allowlist_externals instead of whitelist_externals
    - whitelist_externals is now deprecated, use allowlist_externals instead. see [https://tox.readthedocs.io/en/latest/config.html](https://tox.readthedocs.io/en/latest/config.html)
   
3. Fix ScanCode's import LegacyVersion bug by fixing [packaging ](https://pypi.org/project/packaging/#history)version.
    - https://github.com/nexB/scancode-toolkit/issues/3171


## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

