### PR TITLE
Remove SPDX, URL from copyright

### DIFF
--- a/LICENSES/MIT.txt
+++ b/LICENSES/MIT.txt
@@ -1,0 +1,5 @@
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/src/fosslight_source/_parsing_scancode_file_item.py
+++ b/src/fosslight_source/_parsing_scancode_file_item.py
@@ -85,6 +85,11 @@ def parsing_file_item(scancode_file_list, has_error, need_matched_license=False)
                         else:
                             copyright_data = x.get("value", "")
                         if copyright_data:
+                            try:
+                                copyright_data = re.sub(r'SPDX-License-Identifier\s*[\S]+', '', copyright_data, flags=re.I)
+                                copyright_data = re.sub(r'DownloadLocation\s*[\S]+', '', copyright_data, flags=re.I).strip()
+                            except Exception:
+                                pass
                             copyright_value_list.append(copyright_data)
 
                     result_item.copyright = copyright_value_list

--- a/tests/test_files/sample.cpp
+++ b/tests/test_files/sample.cpp
@@ -1,0 +1,15 @@
+/*
+  * SPDX-FileCopyrightText: Copyright 2022 LG Electronics Inc.
+  * SPDX-License-Identifier: Apache-2.0
+  * DownloadLocation: https://github.com/browserify/acorn-node
+  * SPDX-FileCopyrightText: Copyright 2017 Free Software Foundation Europe e.V.
+  * SPDX-License-Identifier: MIT
+  * DownloadLocation: https://github.com/fsfe/reuse-tool 
+ */
+#include <iostream>
+
+int main()
+{
+    std::cout << "Hello, world!" << std::endl;
+    return 0;
+}

--- a/tests/test_files/temp.cpp
+++ b/tests/test_files/temp.cpp
@@ -1,0 +1,12 @@
+/*
+  * SPDX-FileCopyrightText: Copyright 2022 LG Electronics Inc.
+  * SPDX-License-Identifier: Apache-2.0
+  * DownloadLocation: https://github.com/browserify/acorn-node
+ */
+#include <iostream>
+
+int main()
+{
+    std::cout << "Hello, world!" << std::endl;
+    return 0;
+}


### PR DESCRIPTION
## Description
<!--
Please describe what this PR do.
 -->
Remove SPDX, URL from copyright.
ex. 
Source file : 
```
/*
 * SPDX-FileCopyrightText: Copyright 2022 LG Electronics Inc.
  * SPDX-License-Identifier: Apache-2.0
  * DownloadLocation: https://github.com/browserify/acorn-node
 */
```
Extracted copyright:
- AS-IS: `Copyright 2022 LG Electronics Inc. SPDX-License-Identifier Apache-2.0 DownloadLocation https://github.com/browserify/acorn-node`
- TO-BE: `Copyright 2022 LG Electronics Inc. `

## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

