### PR TITLE
Fix Scancode error in Python 3.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,8 +31,9 @@ if __name__ == "__main__":
                      "Programming Language :: Python :: 3.9", ],
         python_requires=">=3.7",
         install_requires=required,
-        extras_require={":python_version>'3.6'": ["scanoss>=0.7.0"],
-                        ":python_version<'3.7'": ["dataclasses", "scanoss"]},
+        extras_require={":python_version>'3.7'": ["scanoss>=0.7.0"],
+                        ":python_version<'3.7'": ["dataclasses", "scanoss"],
+                        ":python_version=='3.7'": ["scanoss>=0.7.0", "fingerprints==1.0.3"]},
         entry_points={
             "console_scripts": [
                 "fosslight_convert = fosslight_source.convert_scancode:main",


### PR DESCRIPTION
## Description
<!--
Please describe what this PR do.
 -->
Fix Scancode error in Python 3.7.
- Error message : `ImportError: cannot import name 'TypedDict' from 'typing'`
- Related Issue : https://github.com/nexB/scancode-toolkit/issues/3246

## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

