### PR TITLE
Remove empty scanoss reference

### DIFF
--- a/src/fosslight_source/_parsing_scanoss_file.py
+++ b/src/fosslight_source/_parsing_scanoss_file.py
@@ -19,16 +19,17 @@ def parsing_extraInfo(scanned_result):
     scanoss_extra_info = []
     for scan_item in scanned_result:
         license_w_source = scan_item.scanoss_reference
-        if license_w_source:
-            extra_item = [scan_item.file, ','.join(license_w_source['component_declared']),
-                          ','.join(license_w_source['file_spdx_tag']),
-                          ','.join(license_w_source['file_header']),
-                          ','.join(license_w_source['license_file']),
-                          ','.join(license_w_source['scancode']),
-                          scan_item.matched_lines, scan_item.fileURL]
-        else:
-            extra_item = [scan_item.file, '', '', '', '', '', scan_item.matched_lines, scan_item.fileURL]
-        scanoss_extra_info.append(extra_item)
+        if scan_item.matched_lines:
+            if license_w_source:
+                extra_item = [scan_item.file, ','.join(license_w_source['component_declared']),
+                              ','.join(license_w_source['file_spdx_tag']),
+                              ','.join(license_w_source['file_header']),
+                              ','.join(license_w_source['license_file']),
+                              ','.join(license_w_source['scancode']),
+                              scan_item.matched_lines, scan_item.fileURL]
+            else:
+                extra_item = [scan_item.file, '', '', '', '', '', scan_item.matched_lines, scan_item.fileURL]
+            scanoss_extra_info.append(extra_item)
     scanoss_extra_info.insert(0, SCANOSS_INFO_HEADER)
     return scanoss_extra_info
 

--- a/src/fosslight_source/_scan_item.py
+++ b/src/fosslight_source/_scan_item.py
@@ -28,8 +28,8 @@ class ScanItem:
     oss_name = ""
     oss_version = ""
     download_location = ""
-    matched_lines = ""
-    fileURL = ""
+    matched_lines = ""  # Only for SCANOSS results
+    fileURL = ""  # Only for SCANOSS results
     license_reference = ""
 
     def __init__(self, value):


### PR DESCRIPTION
## Description
Remove empty values from SCANOSS reference sheet created with -m option.

## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

