### PR TITLE
Optimize Dockerfile to reduce image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,26 +1,23 @@
 # Copyright (c) 2021 LG Electronics Inc.
 # SPDX-License-Identifier: Apache-2.0
-FROM	ubuntu:20.04
+FROM python:3.8-slim-buster
 
-RUN     apt-get clean
-RUN 	apt-get update && apt-get install sudo -y
-RUN	ln -sf /bin/bash /bin/sh
+RUN ln -sf /bin/bash /bin/sh && \
+    apt-get update && \
+    apt-get install --no-install-recommends -y \
+    build-essential \
+    python3 python3-distutils python3-pip python3-dev python3-magic \
+    libxml2-dev libxslt1-dev libhdf5-dev bzip2 xz-utils zlib1g libpopt0 && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-COPY	. /app
 WORKDIR	/app
 
-ENV 	DEBIAN_FRONTEND=noninteractive
+COPY . /app
 
-RUN	apt-get -y install build-essential
-RUN     apt-get -y install python3 python3-distutils python3-pip python3-dev
-RUN	apt-get -y install python3-intbitset python3-magic
-RUN	apt-get -y install libxml2-dev
-RUN	apt-get -y install libxslt1-dev
-RUN 	apt-get -y install libhdf5-dev
-RUN 	apt-get -y install bzip2 xz-utils zlib1g libpopt0 
-RUN	apt-get -y install gcc-10 g++-10
-RUN	pip3 install --upgrade pip
-RUN	pip3 install .
-RUN	pip3 install dparse
+RUN pip3 install --upgrade pip && \
+    pip3 install . && \
+    pip3 install dparse && \
+    rm -rf ~/.cache/pip /root/.cache/pipe
 
-ENTRYPOINT ["/usr/local/bin/fosslight_source"] 
+ENTRYPOINT ["/usr/local/bin/fosslight_source"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ typecode-libmagic
 fosslight_util>=1.4.28
 PyYAML
 wheel>=0.38.1
+intbitset


### PR DESCRIPTION
## Description
<!--
Please describe what this PR do.
 -->
ref #135 

Changed docker base image from `ubuntu:20.04` to `python:3.8-slim-buster`
Reduced the number of layers

Reduced 0.31GB of the image size

![image](https://github.com/fosslight/fosslight_source_scanner/assets/77962265/9e68feeb-2308-4c26-9e9b-f38cbd60bb3a)

build time also decreased from 5.5 min to 2 min in my environment (Win10, i5-10400F, 16GB RAM)


## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

