### PR TITLE
Create run_scanners for api and exclude unwanted outputs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ typecode-libmagic
 fosslight_util>=1.4.28
 PyYAML
 wheel>=0.38.1
+fosslight_binary

--- a/src/fosslight_source/_scan_item.py
+++ b/src/fosslight_source/_scan_item.py
@@ -14,6 +14,7 @@ _exclude_filename = ["changelog", "config.guess", "config.sub",
                      "aclocal.m4", "configure", "configure.ac",
                      "depcomp", "compile", "missing", "libtool.m4",
                      "makefile"]
+_exclude_extension = [".m4"]
 _exclude_directory = ["test", "tests", "doc", "docs"]
 _exclude_directory = [os.path.sep + dir_name +
                       os.path.sep for dir_name in _exclude_directory]
@@ -104,6 +105,8 @@ def is_exclude_dir(dir_path):
 def is_exclude_file(file_path, prev_dir=None, prev_dir_exclude_value=None):
     file_path = file_path.lower()
     filename = os.path.basename(file_path)
+    if os.path.splitext(filename)[1] in _exclude_extension:
+        return True
     if filename in _exclude_filename:
         return True
 

--- a/src/fosslight_source/run_scancode.py
+++ b/src/fosslight_source/run_scancode.py
@@ -15,8 +15,7 @@ from fosslight_util.set_log import init_log
 from ._parsing_scancode_file_item import parsing_file_item
 from ._parsing_scancode_file_item import get_error_from_header
 from ._license_matched import get_license_list_to_print
-from fosslight_util.output_format import check_output_format, write_output_file
-from fosslight_util.correct import correct_with_yaml
+from fosslight_util.output_format import check_output_format
 
 logger = logging.getLogger(constant.LOGGER_NAME)
 warnings.filterwarnings("ignore", category=FutureWarning)

--- a/src/fosslight_source/run_scancode.py
+++ b/src/fosslight_source/run_scancode.py
@@ -103,23 +103,6 @@ def run_scan(path_to_scan, output_file_name="",
                             if need_license:
                                 sheet_list["matched_text"] = get_license_list_to_print(license_list)
 
-                            output_file_without_ext = os.path.join(output_path, output_file)
-                            if not called_by_cli:
-                                if correct_mode:
-                                    correct_success = True
-                                    correct_success, msg_correct, correct_list = correct_with_yaml(correct_filepath,
-                                                                                                   path_to_scan, sheet_list)
-                                    if not correct_success:
-                                        logger.info(f"No correction with yaml: {msg_correct}")
-                                    else:
-                                        sheet_list = correct_list
-                                        logger.info("Success to correct with yaml.")
-                                success_to_write, writing_msg, result_file = write_output_file(output_file_without_ext,
-                                                                                               output_extension, sheet_list)
-                                if success_to_write:
-                                    logger.info(f"Writing Output file({result_file}, success:{success_to_write}")
-                                else:
-                                    logger.error(f"Fail to generate result file. msg:({writing_msg})")
             except Exception as ex:
                 success = False
                 msg = str(ex)

--- a/src/fosslight_source/run_scancode.py
+++ b/src/fosslight_source/run_scancode.py
@@ -16,6 +16,7 @@ from ._parsing_scancode_file_item import parsing_file_item
 from ._parsing_scancode_file_item import get_error_from_header
 from ._license_matched import get_license_list_to_print
 from fosslight_util.output_format import check_output_format
+from fosslight_binary.binary_analysis import check_binary
 
 logger = logging.getLogger(constant.LOGGER_NAME)
 warnings.filterwarnings("ignore", category=FutureWarning)
@@ -98,6 +99,11 @@ def run_scan(path_to_scan, output_file_name="",
                                 success = True
                             result_list = sorted(
                                 result_list, key=lambda row: (''.join(row.licenses)))
+
+                            for scan_item in result_list:
+                                if check_binary(os.path.join(path_to_scan, scan_item.file)):
+                                    scan_item.exclude = True
+
                             sheet_list["SRC_FL_Source"] = [scan_item.get_row_to_print() for scan_item in result_list]
                             if need_license:
                                 sheet_list["matched_text"] = get_license_list_to_print(license_list)

--- a/src/fosslight_source/run_scancode.py
+++ b/src/fosslight_source/run_scancode.py
@@ -106,9 +106,10 @@ def run_scan(path_to_scan, output_file_name="",
                             output_file_without_ext = os.path.join(output_path, output_file)
                             if not called_by_cli:
                                 if correct_mode:
-                                    success, msg_correct, correct_list = correct_with_yaml(correct_filepath,
-                                                                                           path_to_scan, sheet_list)
-                                    if not success:
+                                    correct_success = True
+                                    correct_success, msg_correct, correct_list = correct_with_yaml(correct_filepath,
+                                                                                                   path_to_scan, sheet_list)
+                                    if not correct_success:
                                         logger.info(f"No correction with yaml: {msg_correct}")
                                     else:
                                         sheet_list = correct_list


### PR DESCRIPTION
## Description
- Create run_scanners so that FL Scanner can call via api
- Make value of Exclude column for binary and .m4 files as "Exclude"
- Remove deprecated code for correct mode

## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

