### PR TITLE
Modify it to work on mac ARM chip

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
-pyparsing<=3.0.4;python_full_version<"3.6.8"
-scancode-toolkit==32.0.6
+pyparsing
+scancode-toolkit==32.0.2
 XlsxWriter
-typecode-libmagic
 fosslight_util>=1.4.28
 PyYAML
 wheel>=0.38.1


### PR DESCRIPTION
## Description
<!--
Please describe what this PR do.
 -->
Change to the version of ScanCode that runs on mac ARM.
On Mac, the following warning message occurs because typecode-libmagic is not installed. (typecode-libmagic cannot be installed on Mac Arm)
- `UserWarning: Libmagic magic database not found. A default will be used if possible. Install instead a typecode-libmagic plugin for best support.
OR set the TYPECODE_LIBMAGIC_DB_PATH environment variable.
  warnings.warn(
`

## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

