### PR TITLE
Check notice file name for scancode

### DIFF
--- a/src/fosslight_source/_parsing_scancode_file_item.py
+++ b/src/fosslight_source/_parsing_scancode_file_item.py
@@ -12,6 +12,7 @@ from ._scan_item import ScanItem
 from ._scan_item import is_exclude_dir
 from ._scan_item import is_exclude_file
 from ._scan_item import replace_word
+from ._scan_item import is_notice_file
 
 logger = logging.getLogger(constant.LOGGER_NAME)
 _exclude_directory = ["test", "tests", "doc", "docs"]
@@ -265,7 +266,7 @@ def parsing_scancode_32_later(scancode_file_list, has_error=False):
                         result_item.comment = license_expression
 
                 result_item.exclude = is_exclude_file(file_path)
-                result_item.is_license_text = file.get("percentage_of_license_text", 0) > 90
+                result_item.is_license_text = file.get("percentage_of_license_text", 0) > 90 or is_notice_file(file_path)
                 scancode_file_item.append(result_item)
             except Exception as ex:
                 msg.append(f"Error Parsing item: {ex}")

--- a/src/fosslight_source/_scan_item.py
+++ b/src/fosslight_source/_scan_item.py
@@ -5,10 +5,14 @@
 
 import os
 import logging
+import re
 import fosslight_util.constant as constant
 
 logger = logging.getLogger(constant.LOGGER_NAME)
 replace_word = ["-only", "-old-style", "-or-later", "licenseref-scancode-", "licenseref-"]
+_notice_filename = ['licen[cs]e[s]?', 'notice[s]?', 'legal', 'copyright[s]?', 'copying*', 'patent[s]?', 'unlicen[cs]e', 'eula',
+                    '[a,l]?gpl[-]?[1-3]?[.,-,_]?[0-1]?', 'mit', 'bsd[-]?[0-4]?', 'bsd[-]?[0-4][-]?clause[s]?',
+                    'apache[-,_]?[1-2]?[.,-,_]?[0-2]?']
 _exclude_filename = ["changelog", "config.guess", "config.sub", "changes", "ltmain.sh",
                      "configure", "configure.ac", "depcomp", "compile", "missing", "makefile"]
 _exclude_extension = [".m4", ".in", ".po"]
@@ -119,3 +123,10 @@ def is_exclude_file(file_path, prev_dir=None, prev_dir_exclude_value=None):
     else:  # running SCANOSS
         return is_exclude_dir(dir_path)
     return False
+
+
+def is_notice_file(file_path):
+    pattern = r"({})(?<!w)".format("|".join(_notice_filename))
+    file_path = file_path.lower()
+    filename = os.path.basename(file_path)
+    return bool(re.match(pattern, filename))


### PR DESCRIPTION
## Description
Set is_license_text as True if file name matches with following regex.
['licen[cs]e[s]?', 'notice[s]?', 'legal', 'copyright[s]?', 'copying*', 'patent[s]?', 'unlicen[cs]e', 'eula','[a,l]?gpl[-]?[1-3]?[.,-,_]?[0-1]?', 'mit', 'bsd[-]?[0-4]?', 'bsd[-]?[0-4][-]?clause[s]?','apache[-,_]?[1-2]?[.,-,_]?[0-2]?']

## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

