### PR TITLE
Enable multiple input for -f and -o option

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ pyparsing
 scancode-toolkit==32.0.6
 scanoss
 XlsxWriter
-fosslight_util>=1.4.43
+fosslight_util>=1.4.46
 PyYAML
 wheel>=0.38.1
 intbitset

--- a/src/fosslight_source/_help.py
+++ b/src/fosslight_source/_help.py
@@ -20,7 +20,7 @@ _HELP_MESSAGE_SOURCE_SCANNER = """
             -m\t\t\t   Print additional information for scan result on separate sheets
             -e <path>\t\t   Path to exclude from analysis (file and directory)
             -o <output_path>\t   Output path (Path or file name)
-            -f <format>\t\t   Output file format (excel, csv, opossum, yaml)
+            -f <format>\t\t   Output file formats (excel, csv, opossum, yaml). Multi formats are supported.
         Options only for FOSSLight Source Scanner
             -s <scanner>\t   Select which scanner to be run (scancode, scanoss, all)
             -j\t\t\t   Generate raw result of scanners in json format

--- a/src/fosslight_source/cli.py
+++ b/src/fosslight_source/cli.py
@@ -158,10 +158,7 @@ def create_report_file(_start_time, merged_result, license_list, scanoss_result,
     else:
         output_path = os.path.abspath(output_path)
 
-    if output_files and output_files[0]:
-        # If -o contains file name, set all output file name and dont' use default name
-        output_files = [output_files[0] for _ in range(len(output_extensions))]
-    else:
+    if not output_files:
         # If -o does not contains file name, set default name
         while len(output_files) < len(output_extensions):
             output_files.append(None)
@@ -218,12 +215,8 @@ def create_report_file(_start_time, merged_result, license_list, scanoss_result,
     combined_paths_and_files = [os.path.join(output_path, file) for file in output_files]
     results = []
     for combined_path_and_file, output_extension in zip(combined_paths_and_files, output_extensions):
-        if need_license:
-            if output_extension == _json_ext:
-                sheet_list["scancode_reference"] = get_license_list_to_print(license_list)
-            elif selected_scanner == 'scanoss':
-                if "scancode_reference" in sheet_list:
-                    del sheet_list["scancode_reference"]
+        if need_license and output_extension == _json_ext and "scanoss_reference" in sheet_list:
+            del sheet_list["scanoss_reference"]
         results.append(write_output_file(combined_path_and_file, output_extension, sheet_list, extended_header, "", cover))
     for success, msg, result_file in results:
         if success:

--- a/src/fosslight_source/run_scanoss.py
+++ b/src/fosslight_source/run_scanoss.py
@@ -11,7 +11,7 @@ import json
 from datetime import datetime
 import fosslight_util.constant as constant
 from fosslight_util.set_log import init_log
-from fosslight_util.output_format import check_output_format  # , write_output_file
+from fosslight_util.output_format import check_output_formats  # , write_output_file
 from ._parsing_scanoss_file import parsing_scanResult  # scanoss
 from ._parsing_scanoss_file import parsing_extraInfo  # scanoss
 import shutil
@@ -41,7 +41,7 @@ def run_scanoss_py(path_to_scan, output_file_name="", format="", called_by_cli=F
     :param write_json_file: if requested, keep the raw files.
     :return scanoss_file_list: list of ScanItem (scanned result by files).
     """
-    success, msg, output_path, output_file, output_extension = check_output_format(output_file_name, format)
+    success, msg, output_path, output_files, output_extensions = check_output_formats(output_file_name, format)
 
     if not called_by_cli:
         global logger

--- a/tox.ini
+++ b/tox.ini
@@ -52,4 +52,8 @@ commands =
   pip install fosslight_android
   fosslight -v
   fosslight_android -v
+
+[testenv:flake8]
+deps = flake8
+commands = flake8
  


### PR DESCRIPTION
## Description
Enable multiple input for -f option.

Example 1)
Command : $fosslight_source **-o abc/output.xlsx -f csv excel**
Output
 - abc/fosslight_log_src_YYMMDD_HHMM.txt
 - abc/output.**csv**
 - abc/output.**xlsx**

Example 2)
Command : $fosslight_source **-o abc/output.xlsx -f excel** -j
Output
 - abc/fosslight_log_src_YYMMDD_HHMM.txt
 - abc/output.**xlsx**
 - abc/scancode_raw_result.json
 - abc/scanner_output.wfp
 - abc/scanoss_raw_result.json

Example 3)
Command : $fosslight_source **-o abc -f csv excel**
Output
 - abc/fosslight_log_src_YYMMDD_HHMM.txt
 - abc/fosslight_report_src_YYMMDD_HHMM.**csv**
 - abc/fosslight_report_src_YYMMDD_HHMM.**xlsx**

Example 4)
Command : $fosslight_source **-f csv excel**
Output
 - fosslight_log_src_YYMMDD_HHMM.txt
 - fosslight_report_src_YYMMDD_HHMM.**csv**
 - fosslight_report_src_YYMMDD_HHMM.**xlsx**

Example 5)
Command : $fosslight_source **-o abc/output.json -f csv excel**
Error : 
> [FOSSLIGHT_SOURCE] Scan Result: Format error. The format of output file(-o:'abc/output.json') should
  be in the format list(-f:'['csv', 'excel']').
Output
 - abc/fosslight_log_src_YYMMDD_HHMM.txt

## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

