### PR TITLE
Upgrade Scancode Toolkit version to 32.2.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ pyparsing
 scancode-toolkit>=32.2.1,==32.2.*
 scanoss
 XlsxWriter
-fosslight_util>=1.4.47
+fosslight_util>=1.4.47,==1.4.*
 PyYAML
 wheel>=0.38.1
 intbitset

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pyparsing
-scancode-toolkit>=32.0.2,==32.0.*
+scancode-toolkit>=32.2.1,==32.2.*
 scanoss
 XlsxWriter
 fosslight_util>=1.4.47


### PR DESCRIPTION
## Description
<!--
Please describe what this PR do.
 -->
A new version of scancode-toolkit has been released. It is currently set to 32.0.2, but version 32.2.1 was released on July 1, 2024.
So, I upgraded the version to 32.2.1.

## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related Issue
https://github.com/fosslight/fosslight_source_scanner/issues/171