### PR TITLE
Remove typecode-libmagic from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,3 @@ PyYAML
 wheel>=0.38.1
 intbitset
 fosslight_binary>=5.0.0
-typecode-libmagic;sys_platform!="darwin"


### PR DESCRIPTION
## Description
<!--
Please describe what this PR do.
 -->
This PR removes the following line from requirements.txt:
`typecode-libmagic;sys_platform!="darwin"`
Reason for removal:
The typecode-libmagic package was causing installation errors in our Docker environment. This dependency is not essential for the core functionality of our project and was leading to build failures.

Changes made:

Deleted the line specifying typecode-libmagic from requirements.txt

Impact:

Resolves Docker build failures related to this package
May affect file type detection capabilities in non-Darwin environments (if this feature was being used)

Next steps:

Monitor for any unintended side effects in file type detection (if applicable)
Consider alternative solutions for file type detection if needed in the future
## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

