### PR TITLE
Fix errors related to SCANOSS

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pyparsing
-scanoss
+scanoss<=1.14.0
 XlsxWriter
 fosslight_util>=2.1.1
 PyYAML

--- a/src/fosslight_source/run_scanoss.py
+++ b/src/fosslight_source/run_scanoss.py
@@ -64,6 +64,8 @@ def run_scanoss_py(path_to_scan: str, output_file_name: str = "", format: list =
         if not os.path.isdir(output_path):
             Path(output_path).mkdir(parents=True, exist_ok=True)
     output_json_file = os.path.join(output_path, SCANOSS_OUTPUT_FILE)
+    if os.path.exists(output_json_file):  # remove scanner_output.wfp file if exist
+        os.remove(output_json_file)
 
     try:
         scanner = Scanner(


### PR DESCRIPTION
## Description
Set the SCANOSS version to same or older then 1.14.0
Remove SCANOSS Raw file before scanning, if exist

## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

