### PR TITLE
Fix github action warning message

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -45,7 +45,9 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        brew install openssl
+        if ! brew list openssl@3 &>/dev/null; then
+            brew install openssl@3
+        fi
         brew install libmagic
         brew install postgresql
         python -m pip install --upgrade pip


### PR DESCRIPTION
## Description
<!--
Please describe what this PR do.
 -->
- Remove warning msg when install brew
    - msg : 'openssl@3 3.4.1 is already installed and up-to-date. To reinstall 3.4.1, run: brew reinstall openssl@3'

## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

