### PR TITLE
Add KB to Scanner Type

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ scancode-toolkit>=32.0.2
 fingerprints==1.2.3
 normality==2.6.1
 click==8.2.1
+swh.model

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,3 @@ scancode-toolkit>=32.0.2
 fingerprints==1.2.3
 normality==2.6.1
 click==8.2.1
-swh.model

--- a/src/fosslight_source/_help.py
+++ b/src/fosslight_source/_help.py
@@ -25,7 +25,7 @@ _HELP_MESSAGE_SOURCE_SCANNER = f"""
             \t\t\t   ({', '.join(SUPPORT_FORMAT)})
             \t\t\t   Multiple formats can be specified separated by space.
         Options only for FOSSLight Source Scanner
-            -s <scanner>\t   Select which scanner to be run (scancode, scanoss, all)
+            -s <scanner>\t   Select which scanner to be run (scancode, scanoss, osskb, all)
             -j\t\t\t   Generate raw result of scanners in json format
             -t <float>\t\t   Stop scancode scanning if scanning takes longer than a timeout in seconds.
             -c <core>\t\t   Select the number of cores to be scanned with ScanCode or threads with SCANOSS.

--- a/src/fosslight_source/_scan_item.py
+++ b/src/fosslight_source/_scan_item.py
@@ -175,7 +175,7 @@ class SourceItem(FileItem):
                 self.oss_items.append(item)
         else:
             item = OssItem(self.oss_name, self.oss_version, self.licenses)
-            if run_osskb:
+            if run_osskb and not self.is_license_text:
                 md5_hash = self._get_md5_hash(path_to_scan)
                 if md5_hash:
                     origin_url = self._get_origin_url_from_md5_hash(md5_hash)

--- a/src/fosslight_source/cli.py
+++ b/src/fosslight_source/cli.py
@@ -270,13 +270,14 @@ def create_report_file(
     return scan_item
 
 
-def merge_results(scancode_result: list = [], scanoss_result: list = [], spdx_downloads: dict = {}) -> list:
+def merge_results(scancode_result: list = [], scanoss_result: list = [], spdx_downloads: dict = {}, path_to_scan: str = "") -> list:
 
     """
     Merge scanner results and spdx parsing result.
     :param scancode_result: list of scancode results in SourceItem.
     :param scanoss_result: list of scanoss results in SourceItem.
     :param spdx_downloads: dictionary of spdx parsed results.
+    :param path_to_scan: path to the scanned directory for constructing absolute file paths.
     :return merged_result: list of merged result in SourceItem.
     """
 
@@ -296,7 +297,7 @@ def merge_results(scancode_result: list = [], scanoss_result: list = [], spdx_do
                 scancode_result.append(new_result_item)
 
     for item in scancode_result:
-        item.set_oss_item()
+        item.set_oss_item(path_to_scan)
 
     return scancode_result
 
@@ -357,7 +358,7 @@ def run_scanners(
                                                               num_cores, path_to_exclude)
         if selected_scanner in SCANNER_TYPE:
             spdx_downloads = get_spdx_downloads(path_to_scan, path_to_exclude)
-            merged_result = merge_results(scancode_result, scanoss_result, spdx_downloads)
+            merged_result = merge_results(scancode_result, scanoss_result, spdx_downloads, path_to_scan)
             scan_item = create_report_file(start_time, merged_result, license_list, scanoss_result, selected_scanner,
                                            print_matched_text, output_path, output_files, output_extensions, correct_mode,
                                            correct_filepath, path_to_scan, path_to_exclude, formats, excluded_file_list,

--- a/src/fosslight_source/cli.py
+++ b/src/fosslight_source/cli.py
@@ -318,7 +318,7 @@ def merge_results(
     if run_osskb:
         logger.info("OSS KB server is reachable. Loading data from OSS KB.")
     else:
-        logger.info(f"Skipping OSS KB lookup.")
+        logger.info("Skipping OSS KB lookup.")
 
     for item in scancode_result:
         item.set_oss_item(path_to_scan, run_osskb)


### PR DESCRIPTION
## Description
<!--
Please describe what this PR do.
 -->
- **OSS KB Integration**: Added support for `-s kb` scanner option to query OSS KB API for automatic OSS identification
    - **Automatic OSS Metadata Extraction** (Only for GitHub): 
       - Extracts repository name and version from GitHub URLs
       - Converts download URLs to repository URLs (`https://github.com/{owner}/{repo}`)
       - Automatically populates `oss_name` and `oss_version` fields

## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

