### PR TITLE
Remove pyopenssl pin from requirements-dev.txt

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,4 +7,3 @@ dataclasses
 scanoss
 importlib-metadata
 pytest-xdist
-pyopenssl>=26.0.0 # not directly required, pinned by Snyk to avoid a vulnerability


### PR DESCRIPTION
## Description
<!--
Please describe what this PR do.
 -->
Remove the pyopenssl>=26.0.0 line that was pinned by Snyk as a
transitive vulnerability fix. It is not a direct dependency and
does not belong in dev requirements.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->