### PR TITLE
Support Hugging Face metadata license extraction in manifest flow

### DIFF
--- a/src/fosslight_source/_scan_item.py
+++ b/src/fosslight_source/_scan_item.py
@@ -19,7 +19,15 @@ replace_word = ["-only", "-old-style", "-or-later", "licenseref-scancode-", "lic
 _notice_filename = ['licen[cs]e[s]?', 'notice[s]?', 'legal', 'copyright[s]?', 'copying*', 'patent[s]?', 'unlicen[cs]e', 'eula',
                     '[a,l]?gpl[-]?[1-3]?[.,-,_]?[0-1]?', 'mit', 'bsd[-]?[0-4]?', 'bsd[-]?[0-4][-]?clause[s]?',
                     'apache[-,_]?[1-2]?[.,-,_]?[0-2]?']
-_manifest_filename = [r'.*\.pom$', r'package\.json$', r'setup\.py$', r'setup\.cfg$', r'.*\.podspec$', r'Cargo\.toml$']
+_manifest_filename = [
+    r'.*\.pom$',
+    r'package\.json$',
+    r'setup\.py$',
+    r'setup\.cfg$',
+    r'.*\.podspec$',
+    r'Cargo\.toml$',
+    r'huggingface_hub_metadata\.json$',
+]
 MAX_LICENSE_LENGTH = 200
 MAX_LICENSE_TOTAL_LENGTH = 600
 SUBSTRING_LICENSE_COMMENT = "Maximum character limit (License)"

--- a/src/fosslight_source/cli.py
+++ b/src/fosslight_source/cli.py
@@ -346,15 +346,18 @@ def merge_results(
                 scancode_result.append(new_result_item)
     if manifest_licenses:
         for file_name, licenses in manifest_licenses.items():
+            valid_licenses = [lic.strip() for lic in licenses if isinstance(lic, str) and lic.strip()]
+            if not valid_licenses:
+                continue
             if file_name in scancode_result:
                 merged_result_item = scancode_result[scancode_result.index(file_name)]
                 # overwrite existing detected licenses with manifest-provided licenses
                 merged_result_item.licenses = []  # clear existing licenses (setter clears when value falsy)
-                merged_result_item.licenses = licenses
+                merged_result_item.licenses = valid_licenses
                 merged_result_item.is_manifest_file = True
             else:
                 new_result_item = SourceItem(file_name)
-                new_result_item.licenses = licenses
+                new_result_item.licenses = valid_licenses
                 new_result_item.is_manifest_file = True
                 scancode_result.append(new_result_item)
 

--- a/src/fosslight_source/run_manifest_extractor.py
+++ b/src/fosslight_source/run_manifest_extractor.py
@@ -207,6 +207,49 @@ def get_licenses_from_cargo_toml(file_path: str) -> list[str]:
     return []
 
 
+def get_licenses_from_huggingface_metadata(file_path: str) -> list[str]:
+    try:
+        with open(file_path, 'r', encoding='utf-8') as f:
+            data = json.load(f)
+    except Exception as ex:
+        logger.info(f"Failed to read huggingface_hub_metadata.json {file_path}: {ex}")
+        return []
+
+    if not isinstance(data, dict):
+        return []
+
+    licenses: list[str] = []
+
+    def append_license(value):
+        if isinstance(value, str):
+            token = value.strip()
+            if token and token not in licenses:
+                licenses.append(token)
+        elif isinstance(value, list):
+            for item in value:
+                append_license(item)
+
+    # Hugging Face model API commonly returns top-level `license`
+    append_license(data.get('license'))
+
+    # Some metadata may include cardData/license variants
+    card_data = data.get('cardData')
+    if isinstance(card_data, dict):
+        append_license(card_data.get('license'))
+        append_license(card_data.get('licenses'))
+
+    # Many Hub API responses expose license only via tags, e.g. "license:apache-2.0".
+    tags = data.get('tags')
+    if isinstance(tags, list):
+        for tag in tags:
+            if isinstance(tag, str):
+                prefix = 'license:'
+                if tag.lower().startswith(prefix):
+                    append_license(tag[len(prefix):].strip())
+
+    return licenses
+
+
 def get_manifest_licenses(file_path: str) -> list[str]:
     if file_path.endswith('.pom'):
         try:
@@ -246,4 +289,10 @@ def get_manifest_licenses(file_path: str) -> list[str]:
             return get_licenses_from_cargo_toml(file_path)
         except Exception as ex:
             logger.info(f"Failed to extract license from Cargo.toml {file_path}: {ex}")
+            return []
+    elif os.path.basename(file_path).lower() == 'huggingface_hub_metadata.json':
+        try:
+            return get_licenses_from_huggingface_metadata(file_path)
+        except Exception as ex:
+            logger.info(f"Failed to extract license from huggingface_hub_metadata.json {file_path}: {ex}")
             return []


### PR DESCRIPTION
* **New Features**
  * Added support for Hugging Face metadata files as manifest sources during scanning
  * Implemented license extraction from Hugging Face metadata files

* **Bug Fixes**
  * Improved license sanitization by filtering empty or invalid license entries