### PR TITLE
Exclude OSS info correction files

### DIFF
--- a/src/fosslight_source/cli.py
+++ b/src/fosslight_source/cli.py
@@ -9,6 +9,7 @@ import platform
 import time
 import warnings
 import logging
+import re
 import urllib.request
 import urllib.error
 from datetime import datetime
@@ -18,6 +19,7 @@ from ._help import print_version, print_help_msg_source_scanner
 from ._license_matched import get_license_list_to_print
 from fosslight_util.output_format import check_output_formats_v2, write_output_file
 from fosslight_util.correct import correct_with_yaml
+from fosslight_util.parsing_yaml import SUPPORT_OSS_INFO_FILES
 from .run_scancode import run_scan
 from fosslight_util.exclude import get_excluded_paths
 from .run_scanoss import run_scanoss_py
@@ -43,6 +45,7 @@ MERGED_HEADER = {SRC_SHEET_NAME: ['ID', 'Source Path', 'OSS Name',
 KB_REFERENCE_HEADER = ['ID', 'Source Path', 'KB Origin URL', 'Evidence']
 ALL_MODE = 'all'
 SCANNER_TYPE = ['kb', 'scancode', 'scanoss', ALL_MODE]
+OSS_INFO_CORRECTION_COMMENT = "Excluded because it's OSS info correction file"
 
 
 logger = logging.getLogger(constant.LOGGER_NAME)
@@ -312,6 +315,14 @@ def get_kb_reference_to_print(merged_result: list) -> list:
     return data
 
 
+def mark_oss_info_correction_files_as_excluded(scan_results: list) -> None:
+    for item in scan_results:
+        file_name = os.path.basename(item.source_name_or_path).lower()
+        if any(re.search(pattern, file_name, re.IGNORECASE) for pattern in SUPPORT_OSS_INFO_FILES):
+            item.exclude = True
+            item.comment = OSS_INFO_CORRECTION_COMMENT
+
+
 def merge_results(
     scancode_result: list = [], scanoss_result: list = [], spdx_downloads: dict = {},
     path_to_scan: str = "", run_kb: bool = False, manifest_licenses: dict = {},
@@ -483,6 +494,7 @@ def run_scanners(
             spdx_downloads, manifest_licenses = metadata_collector(path_to_scan, excluded_files)
             merged_result = merge_results(scancode_result, scanoss_result, spdx_downloads,
                                           path_to_scan, run_kb, manifest_licenses, excluded_files, hide_progress)
+            mark_oss_info_correction_files_as_excluded(merged_result)
             scan_item = create_report_file(start_time, merged_result, license_list, scanoss_result, selected_scanner,
                                            print_matched_text, output_path, output_files, output_extensions, correct_mode,
                                            correct_filepath, path_to_scan, excluded_path_without_dot, formats,


### PR DESCRIPTION
## New Features
  * Automatic exclusion of configured OSS-info correction files from scan results. Matching files are now marked as excluded and annotated during the scanning workflow so they do not appear in final generated reports.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fosslight/fosslight_source_scanner/pull/271?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->