### PR TITLE
Add folder summary for source report

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "pyparsing",
     "scanoss>=1.19.0",
     "XlsxWriter",
-    "fosslight_util>=2.1.37",
+    "fosslight_util>=2.1.62",
     "PyYAML",
     "wheel>=0.38.1",
     "intbitset",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ dependencies = [
     "psycopg2-binary>=2.9.10; python_version >= '3.13'",
     "tomli; python_version < '3.11'",
     "tqdm",
+    "defusedxml",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "pyparsing",
     "scanoss>=1.19.0",
     "XlsxWriter",
-    "fosslight_util>=2.1.62",
+    "fosslight_util>=2.1.64",
     "PyYAML",
     "wheel>=0.38.1",
     "intbitset",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,6 @@ dependencies = [
     "psycopg2-binary>=2.9.10; python_version >= '3.13'",
     "tomli; python_version < '3.11'",
     "tqdm",
-    "defusedxml",
 ]
 
 [project.optional-dependencies]

--- a/src/fosslight_source/_help.py
+++ b/src/fosslight_source/_help.py
@@ -44,6 +44,7 @@ _HELP_MESSAGE_SOURCE_SCANNER = f"""
     --hide_progress        Hide the progress bar during scanning
     --kb_url <url>         KB API URL (priority: parameter > KB_URL env > default)
     --kb_token <token>     KB bearer token (priority: parameter > KB_TOKEN env)
+    --no_merge             Keep source paths file-based without folder merge
 
     💡 Examples
     ────────────────────────────────────────────────────────────────────

--- a/src/fosslight_source/_help.py
+++ b/src/fosslight_source/_help.py
@@ -39,12 +39,12 @@ _HELP_MESSAGE_SOURCE_SCANNER = f"""
     -c <number>            Number of CPU cores/threads to use for scanning
     -t <seconds>           Timeout in seconds for ScanCode scanning
     -j                     Generate raw scanner results in JSON format
+    --no_merge             Keep source paths file-based without folder merge
     --no_correction        Skip OSS information correction with sbom-info.yaml
     --correct_fpath <path> Path to custom sbom-info.yaml file
     --hide_progress        Hide the progress bar during scanning
     --kb_url <url>         KB API URL (priority: parameter > KB_URL env > default)
     --kb_token <token>     KB bearer token (priority: parameter > KB_TOKEN env)
-    --no_merge             Keep source paths file-based without folder merge
 
     💡 Examples
     ────────────────────────────────────────────────────────────────────

--- a/src/fosslight_source/_merge.py
+++ b/src/fosslight_source/_merge.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# Copyright (c) 2020 LG Electronics Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import copy
+import logging
+import zipfile
+import tempfile
+import shutil
+import defusedxml.ElementTree as ET
+import xml.etree.ElementTree as xmlET
+from collections import Counter
+
+import fosslight_util.constant as constant
+from ._scan_item import SourceItem
+from fosslight_util.oss_item import ScannerItem
+
+logger = logging.getLogger(constant.LOGGER_NAME)
+
+PKG_NAME = "fosslight_source"
+SRC_SHEET_NAME = 'SRC_FL_Source'
+PRE_MERGE_SHEET_NAME = '.SRC_FL_Source_no_merge'
+
+MERGED_HEADER = {SRC_SHEET_NAME: ['ID', 'Source Path', 'OSS Name',
+                                  'OSS Version', 'License', 'Download Location',
+                                  'Homepage', 'Copyright Text', 'Exclude', 'Comment', 'license_reference']}
+
+
+def _get_source_rows_to_print(source_items: list) -> list:
+    source_rows = []
+    for source_item in source_items:
+        source_rows.extend(source_item.get_print_array())
+    return source_rows
+
+
+def _add_pre_merge_sheet(scan_item: 'ScannerItem') -> None:
+    external_sheets = getattr(scan_item, "external_sheets", {}) or {}
+    external_sheets[PRE_MERGE_SHEET_NAME] = [
+        MERGED_HEADER[SRC_SHEET_NAME],
+        *_get_source_rows_to_print(scan_item.file_items.get(PKG_NAME, [])),
+    ]
+    scan_item.external_sheets = external_sheets
+
+
+def _hide_xlsx_sheet(xlsx_path: str, sheet_name: str) -> None:
+    workbook_xml_path = "xl/workbook.xml"
+    namespace_uri = "http://schemas.openxmlformats.org/spreadsheetml/2006/main"
+    relationship_uri = "http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+    xmlET.register_namespace("", namespace_uri)
+    xmlET.register_namespace("r", relationship_uri)
+
+    try:
+        with zipfile.ZipFile(xlsx_path, "r") as workbook:
+            try:
+                workbook_xml = workbook.read(workbook_xml_path)
+            except KeyError:
+                logger.debug(f"Failed to hide sheet. workbook.xml not found: {xlsx_path}")
+                return
+
+            root = ET.fromstring(workbook_xml)
+            target_sheet = None
+            for sheet in root.findall(f".//{{{namespace_uri}}}sheet"):
+                if sheet.attrib.get("name") == sheet_name:
+                    target_sheet = sheet
+                    break
+
+            if target_sheet is None:
+                logger.debug(f"Failed to hide sheet. sheet not found: {sheet_name}")
+                return
+
+            target_sheet.set("state", "hidden")
+            updated_workbook_xml = ET.tostring(root, encoding="utf-8", xml_declaration=True)
+
+            output_dir = os.path.dirname(xlsx_path) or "."
+            with tempfile.NamedTemporaryFile(delete=False, dir=output_dir, suffix=".xlsx") as temp_file:
+                temp_xlsx_path = temp_file.name
+
+            try:
+                with zipfile.ZipFile(temp_xlsx_path, "w") as updated_workbook:
+                    for item in workbook.infolist():
+                        if item.filename == workbook_xml_path:
+                            content = updated_workbook_xml
+                        else:
+                            content = workbook.read(item.filename)
+                        updated_workbook.writestr(item, content)
+                shutil.move(temp_xlsx_path, xlsx_path)
+            except Exception:
+                if os.path.exists(temp_xlsx_path):
+                    os.remove(temp_xlsx_path)
+                raise
+    except Exception as ex:
+        logger.debug(f"Failed to hide sheet {sheet_name}: {ex}")
+
+
+def _normalize_merge_text(value: str) -> str:
+    return value.strip() if value else ""
+
+
+def _get_merge_licenses(scan_item: SourceItem) -> tuple:
+    return tuple(sorted([lic.strip() for lic in scan_item.licenses if lic and lic.strip()]))
+
+
+def _get_merge_download_locations(scan_item: SourceItem) -> tuple:
+    downloads = scan_item.download_location
+    if not downloads:
+        return ()
+    if isinstance(downloads, str):
+        downloads = [downloads]
+    return tuple(sorted([dl.strip() for dl in downloads if dl and dl.strip()]))
+
+
+def _get_merge_field_value(scan_items: list, value_getter) -> str:
+    for scan_item in scan_items:
+        value = value_getter(scan_item)
+        if value:
+            return value
+    return ""
+
+
+def _is_merge_field_compatible(scan_items: list, value_getter) -> bool:
+    values = []
+    for scan_item in scan_items:
+        value = value_getter(scan_item)
+        if value:
+            values.append(value)
+    return len(set(values)) <= 1
+
+
+def _iter_merge_values(values) -> list:
+    if not values:
+        return []
+    if isinstance(values, str):
+        return [values]
+    return values
+
+
+def _get_top_merge_values(scan_items: list, value_getter) -> list:
+    values = []
+    for scan_item in scan_items:
+        for value in _iter_merge_values(value_getter(scan_item)):
+            normalized_value = _normalize_merge_text(value)
+            if normalized_value:
+                values.append(normalized_value)
+    return [value for value, _ in Counter(values).most_common(3)]
+
+
+def _can_merge_folder(scan_items: list) -> bool:
+    return (
+        len(scan_items) > 1
+        and _is_merge_field_compatible(scan_items, lambda item: _normalize_merge_text(item.oss_name))
+        and _is_merge_field_compatible(scan_items, lambda item: _normalize_merge_text(item.oss_version))
+        and _is_merge_field_compatible(scan_items, _get_merge_licenses)
+        and _is_merge_field_compatible(scan_items, _get_merge_download_locations)
+    )
+
+
+def _create_merged_item(scan_items: list, merge_path: str) -> SourceItem:
+    # Reuse the shortest path item as the representative row, but keep original paths untouched.
+    representative_item = min(scan_items, key=lambda item: (len(item.source_name_or_path), item.source_name_or_path))
+    merged_item = copy.copy(representative_item)
+    merged_item.source_name_or_path = f"{merge_path} ({len(scan_items)})"
+    merged_item.oss_name = _get_merge_field_value(scan_items, lambda item: _normalize_merge_text(item.oss_name))
+    merged_item.oss_version = _get_merge_field_value(scan_items, lambda item: _normalize_merge_text(item.oss_version))
+    merged_item._licenses = []
+    merged_item.licenses = list(_get_merge_field_value(scan_items, _get_merge_licenses))
+    merged_downloads = _get_merge_field_value(scan_items, _get_merge_download_locations)
+    merged_item.download_location = list(merged_downloads) if merged_downloads else []
+    merged_copyrights = _get_top_merge_values(scan_items, lambda item: item.copyright)
+    merged_item.copyright = merged_copyrights if merged_copyrights else []
+    merged_item.set_oss_item()
+    return merged_item
+
+
+def merge_results_by_folder(scan_result: list) -> list:
+    """
+    Merge output rows within the same folder when OSS name, OSS version, and license are compatible.
+    """
+    # Build a folder tree first so merge never jumps straight to root ".".
+    merge_tree = {"items": [], "children": {}}
+
+    for scan_item in scan_result:
+        normalized_path = os.path.normpath(scan_item.source_name_or_path).replace("\\", "/")
+        path_parts = [part for part in normalized_path.split("/") if part and part != "."]
+        current_node = merge_tree
+
+        for folder_name in path_parts[:-1]:
+            current_node = current_node["children"].setdefault(folder_name, {"items": [], "children": {}})
+        current_node["items"].append(scan_item)
+
+    def merge_node(merge_node_item: dict, merge_path: str = "", depth: int = 0) -> list:
+        excluded_items = [item for item in merge_node_item["items"] if item.exclude]
+        eligible_items = [item for item in merge_node_item["items"] if not item.exclude]
+
+        # Keep at least one path depth in the report; root-level ". (N)" is too broad.
+        if depth > 0 and _can_merge_folder(eligible_items):
+            merged_items = [_create_merged_item(eligible_items, merge_path)] + excluded_items
+        else:
+            merged_items = list(merge_node_item["items"])
+
+        for folder_name, child_node in merge_node_item["children"].items():
+            child_path = f"{merge_path}/{folder_name}" if merge_path else folder_name
+            merged_items.extend(merge_node(child_node, child_path, depth + 1))
+        return merged_items
+
+    return merge_node(merge_tree)

--- a/src/fosslight_source/_merge.py
+++ b/src/fosslight_source/_merge.py
@@ -32,34 +32,69 @@ def _normalize_merge_text(value: str) -> str:
     return value.strip() if value else ""
 
 
-def _get_item_oss_name(item: SourceItem) -> str:
-    if item.oss_items:
-        return item.oss_items[0].name
-    return item.oss_name
+def _iter_merge_values(values) -> list:
+    if not values:
+        return []
+    if isinstance(values, str):
+        return [values]
+    return values
 
 
-def _get_item_oss_version(item: SourceItem) -> str:
-    if item.oss_items:
-        return item.oss_items[0].version
-    return item.oss_version
+def _normalize_merge_licenses(licenses) -> tuple:
+    return tuple(sorted([lic.strip() for lic in _iter_merge_values(licenses) if lic and lic.strip()]))
 
 
-def _get_merge_licenses(scan_item: SourceItem) -> tuple:
-    if scan_item.oss_items:
-        return tuple(sorted([lic.strip() for lic in scan_item.oss_items[0].license if lic and lic.strip()]))
-    return tuple(sorted([lic.strip() for lic in scan_item.licenses if lic and lic.strip()]))
-
-
-def _get_merge_download_locations(scan_item: SourceItem) -> tuple:
-    if scan_item.oss_items:
-        downloads = scan_item.oss_items[0].download_location
-    else:
-        downloads = scan_item.download_location
+def _normalize_merge_downloads(downloads) -> tuple:
     if not downloads:
         return ()
     if isinstance(downloads, str):
         downloads = [downloads]
     return tuple(sorted([dl.strip() for dl in downloads if dl and dl.strip()]))
+
+
+def _iter_merge_rows(item: SourceItem):
+    if item.oss_items:
+        for oss_item in item.oss_items:
+            name = _normalize_merge_text(oss_item.name) or _normalize_merge_text(item.oss_name)
+            version = _normalize_merge_text(oss_item.version) or _normalize_merge_text(item.oss_version)
+            licenses = _normalize_merge_licenses(oss_item.license or item.licenses)
+            downloads = _normalize_merge_downloads(oss_item.download_location or item.download_location)
+            yield name, version, licenses, downloads
+    else:
+        yield (
+            _normalize_merge_text(item.oss_name),
+            _normalize_merge_text(item.oss_version),
+            _normalize_merge_licenses(item.licenses),
+            _normalize_merge_downloads(item.download_location),
+        )
+
+
+def _get_item_oss_name(item: SourceItem) -> str:
+    for name, _, _, _ in _iter_merge_rows(item):
+        if name:
+            return name
+    return ""
+
+
+def _get_item_oss_version(item: SourceItem) -> str:
+    for _, version, _, _ in _iter_merge_rows(item):
+        if version:
+            return version
+    return ""
+
+
+def _get_merge_licenses(scan_item: SourceItem) -> tuple:
+    for _, _, licenses, _ in _iter_merge_rows(scan_item):
+        if licenses:
+            return licenses
+    return ()
+
+
+def _get_merge_download_locations(scan_item: SourceItem) -> tuple:
+    for _, _, _, downloads in _iter_merge_rows(scan_item):
+        if downloads:
+            return downloads
+    return ()
 
 
 def _get_merge_field_value(scan_items: list, value_getter):
@@ -68,14 +103,6 @@ def _get_merge_field_value(scan_items: list, value_getter):
         if value:
             return value
     return ""
-
-
-def _iter_merge_values(values) -> list:
-    if not values:
-        return []
-    if isinstance(values, str):
-        return [values]
-    return values
 
 
 def _get_top_merge_values(scan_items: list, value_getter) -> list:
@@ -98,36 +125,30 @@ def _can_merge_folder(scan_items: list) -> bool:
     ref_downloads = None
 
     for item in scan_items:
-        if len(item.oss_items) > 1:
-            return False
+        for name, version, licenses, downloads in _iter_merge_rows(item):
+            if name:
+                if ref_name is None:
+                    ref_name = name
+                elif name != ref_name:
+                    return False
 
-        name = _normalize_merge_text(_get_item_oss_name(item))
-        if name:
-            if ref_name is None:
-                ref_name = name
-            elif name != ref_name:
-                return False
+            if version:
+                if ref_version is None:
+                    ref_version = version
+                elif version != ref_version:
+                    return False
 
-        version = _normalize_merge_text(_get_item_oss_version(item))
-        if version:
-            if ref_version is None:
-                ref_version = version
-            elif version != ref_version:
-                return False
+            if licenses:
+                if ref_licenses is None:
+                    ref_licenses = licenses
+                elif licenses != ref_licenses:
+                    return False
 
-        licenses = _get_merge_licenses(item)
-        if licenses:
-            if ref_licenses is None:
-                ref_licenses = licenses
-            elif licenses != ref_licenses:
-                return False
-
-        downloads = _get_merge_download_locations(item)
-        if downloads:
-            if ref_downloads is None:
-                ref_downloads = downloads
-            elif downloads != ref_downloads:
-                return False
+            if downloads:
+                if ref_downloads is None:
+                    ref_downloads = downloads
+                elif downloads != ref_downloads:
+                    return False
 
     return True
 
@@ -170,9 +191,9 @@ def merge_results_by_folder(scan_result: list) -> list:
     Merge output rows within the same folder when OSS name, OSS version, license,
     and download location are compatible.
 
-    A field is compatible when non-empty values across rows differ by at most one
-    (empty values are ignored). All eligible rows in the folder must be compatible
-    together; rows are not grouped by key subsets.
+    A field is compatible when all non-empty values across rows are identical
+    (empty values are ignored). Each oss_item is treated as its own row. All eligible
+    rows in the folder must be compatible together; rows are not grouped by key subsets.
     """
     # Build a folder tree first so merge never jumps straight to root ".".
     merge_tree = {"items": [], "children": {}}

--- a/src/fosslight_source/_merge.py
+++ b/src/fosslight_source/_merge.py
@@ -165,11 +165,6 @@ def merge_results_by_folder(scan_result: list) -> list:
             current_node = current_node["children"].setdefault(folder_name, {"items": [], "children": {}})
         current_node["items"].append(scan_item)
 
-    def get_all_eligible_items(node: dict) -> list:
-        items = [item for item in node["items"] if not item.exclude]
-        for child_node in node["children"].values():
-            items.extend(get_all_eligible_items(child_node))
-        return items
 
     def merge_node(merge_node_item: dict, merge_path: str = "", depth: int = 0) -> tuple:
         child_finalized = []
@@ -192,8 +187,7 @@ def merge_results_by_folder(scan_result: list) -> list:
         can_merge_here = (depth > 0) and (len(local_eligible) + len(child_unfinalized) > 1)
 
         if can_merge_here:
-            all_subtree_eligible = get_all_eligible_items(merge_node_item)
-            if _can_merge_folder(all_subtree_eligible):
+            if _can_merge_folder(all_eligible_candidates):
                 new_finalized = child_finalized + local_excluded
                 new_unfinalized = [(merge_path, all_eligible_candidates)]
                 return new_finalized, new_unfinalized

--- a/src/fosslight_source/_merge.py
+++ b/src/fosslight_source/_merge.py
@@ -9,6 +9,7 @@ from collections import Counter
 
 from ._scan_item import SourceItem
 
+
 def _get_source_rows_to_print(source_items: list) -> list:
     source_rows = []
     for source_item in source_items:
@@ -87,6 +88,26 @@ def _can_merge_folder(scan_items: list) -> bool:
     )
 
 
+def _get_merged_comments(scan_items: list) -> str:
+    comments = []
+    for item in scan_items:
+        val = item.comment
+        if val:
+            parts = [p.strip() for p in val.split(" / ") if p.strip()]
+            for p in parts:
+                if p not in comments:
+                    comments.append(p)
+    if not comments:
+        return ""
+
+    delimiter = " / "
+    merged = delimiter.join(comments)
+    max_len = 32767
+    if len(merged) > max_len:
+        merged = merged[:max_len - 3] + "..."
+    return merged
+
+
 def _create_merged_item(scan_items: list, merge_path: str) -> SourceItem:
     # Reuse the shortest path item as the representative row, but keep original paths untouched.
     representative_item = min(scan_items, key=lambda item: (len(item.source_name_or_path), item.source_name_or_path))
@@ -100,6 +121,7 @@ def _create_merged_item(scan_items: list, merge_path: str) -> SourceItem:
     merged_item.download_location = list(merged_downloads) if merged_downloads else []
     merged_copyrights = _get_top_merge_values(scan_items, lambda item: item.copyright)
     merged_item.copyright = merged_copyrights if merged_copyrights else []
+    merged_item._comment = _get_merged_comments(scan_items)
     merged_item.set_oss_item()
     return merged_item
 

--- a/src/fosslight_source/_merge.py
+++ b/src/fosslight_source/_merge.py
@@ -62,7 +62,7 @@ def _get_merge_download_locations(scan_item: SourceItem) -> tuple:
     return tuple(sorted([dl.strip() for dl in downloads if dl and dl.strip()]))
 
 
-def _get_merge_field_value(scan_items: list, value_getter) -> str:
+def _get_merge_field_value(scan_items: list, value_getter):
     for scan_item in scan_items:
         value = value_getter(scan_item)
         if value:
@@ -154,7 +154,8 @@ def _create_merged_item(scan_items: list, merge_path: str) -> SourceItem:
     merged_item.oss_name = _get_merge_field_value(scan_items, lambda item: _normalize_merge_text(_get_item_oss_name(item)))
     merged_item.oss_version = _get_merge_field_value(scan_items, lambda item: _normalize_merge_text(_get_item_oss_version(item)))
     merged_item._licenses = []
-    merged_item.licenses = list(_get_merge_field_value(scan_items, _get_merge_licenses))
+    merged_licenses = _get_merge_field_value(scan_items, _get_merge_licenses)
+    merged_item.licenses = list(merged_licenses) if merged_licenses else []
     merged_downloads = _get_merge_field_value(scan_items, _get_merge_download_locations)
     merged_item.download_location = list(merged_downloads) if merged_downloads else []
     merged_copyrights = _get_top_merge_values(scan_items, lambda item: item.copyright)

--- a/src/fosslight_source/_merge.py
+++ b/src/fosslight_source/_merge.py
@@ -70,15 +70,6 @@ def _get_merge_field_value(scan_items: list, value_getter) -> str:
     return ""
 
 
-def _is_merge_field_compatible(scan_items: list, value_getter) -> bool:
-    values = []
-    for scan_item in scan_items:
-        value = value_getter(scan_item)
-        if value:
-            values.append(value)
-    return len(set(values)) <= 1
-
-
 def _iter_merge_values(values) -> list:
     if not values:
         return []
@@ -100,16 +91,45 @@ def _get_top_merge_values(scan_items: list, value_getter) -> list:
 def _can_merge_folder(scan_items: list) -> bool:
     if len(scan_items) <= 1:
         return False
-    # If any file has multiple OSS components, do not merge this folder
+
+    ref_name = None
+    ref_version = None
+    ref_licenses = None
+    ref_downloads = None
+
     for item in scan_items:
         if len(item.oss_items) > 1:
             return False
-    return (
-        _is_merge_field_compatible(scan_items, lambda item: _normalize_merge_text(_get_item_oss_name(item)))
-        and _is_merge_field_compatible(scan_items, lambda item: _normalize_merge_text(_get_item_oss_version(item)))
-        and _is_merge_field_compatible(scan_items, _get_merge_licenses)
-        and _is_merge_field_compatible(scan_items, _get_merge_download_locations)
-    )
+
+        name = _normalize_merge_text(_get_item_oss_name(item))
+        if name:
+            if ref_name is None:
+                ref_name = name
+            elif name != ref_name:
+                return False
+
+        version = _normalize_merge_text(_get_item_oss_version(item))
+        if version:
+            if ref_version is None:
+                ref_version = version
+            elif version != ref_version:
+                return False
+
+        licenses = _get_merge_licenses(item)
+        if licenses:
+            if ref_licenses is None:
+                ref_licenses = licenses
+            elif licenses != ref_licenses:
+                return False
+
+        downloads = _get_merge_download_locations(item)
+        if downloads:
+            if ref_downloads is None:
+                ref_downloads = downloads
+            elif downloads != ref_downloads:
+                return False
+
+    return True
 
 
 def _get_merged_comments(scan_items: list) -> str:

--- a/src/fosslight_source/_merge.py
+++ b/src/fosslight_source/_merge.py
@@ -5,19 +5,10 @@
 
 import os
 import copy
-import logging
-import zipfile
-import tempfile
-import shutil
-import defusedxml.ElementTree as ET
-import xml.etree.ElementTree as xmlET
 from collections import Counter
 
-import fosslight_util.constant as constant
 from ._scan_item import SourceItem
 from fosslight_util.oss_item import ScannerItem
-
-logger = logging.getLogger(constant.LOGGER_NAME)
 
 PKG_NAME = "fosslight_source"
 SRC_SHEET_NAME = 'SRC_FL_Source'
@@ -42,70 +33,6 @@ def _add_pre_merge_sheet(scan_item: 'ScannerItem') -> None:
         *_get_source_rows_to_print(scan_item.file_items.get(PKG_NAME, [])),
     ]
     scan_item.external_sheets = external_sheets
-
-
-def _hide_xlsx_sheet(xlsx_path: str, sheet_name: str) -> None:
-    workbook_xml_path = "xl/workbook.xml"
-    namespace_uri = "http://schemas.openxmlformats.org/spreadsheetml/2006/main"
-    relationship_uri = "http://schemas.openxmlformats.org/officeDocument/2006/relationships"
-    xmlET.register_namespace("", namespace_uri)
-    xmlET.register_namespace("r", relationship_uri)
-
-    try:
-        with zipfile.ZipFile(xlsx_path, "r") as workbook:
-            try:
-                workbook_xml = workbook.read(workbook_xml_path)
-            except KeyError:
-                logger.debug(f"Failed to hide sheet. workbook.xml not found: {xlsx_path}")
-                return
-
-            root = ET.fromstring(workbook_xml)
-            target_sheet = None
-            for sheet in root.findall(f".//{{{namespace_uri}}}sheet"):
-                if sheet.attrib.get("name") == sheet_name:
-                    target_sheet = sheet
-                    break
-
-            if target_sheet is None:
-                logger.debug(f"Failed to hide sheet. sheet not found: {sheet_name}")
-                return
-
-            target_sheet.set("state", "hidden")
-            updated_workbook_xml = ET.tostring(root, encoding="utf-8", xml_declaration=True)
-
-            output_dir = os.path.dirname(xlsx_path) or "."
-
-            original_mode = None
-            if os.path.exists(xlsx_path):
-                try:
-                    original_mode = os.stat(xlsx_path).st_mode
-                except Exception as ex:
-                    logger.debug(f"Failed to capture original permissions of {xlsx_path}: {ex}")
-
-            with tempfile.NamedTemporaryFile(delete=False, dir=output_dir, suffix=".xlsx") as temp_file:
-                temp_xlsx_path = temp_file.name
-
-            try:
-                with zipfile.ZipFile(temp_xlsx_path, "w") as updated_workbook:
-                    for item in workbook.infolist():
-                        if item.filename == workbook_xml_path:
-                            content = updated_workbook_xml
-                        else:
-                            content = workbook.read(item.filename)
-                        updated_workbook.writestr(item, content)
-                shutil.move(temp_xlsx_path, xlsx_path)
-
-                if original_mode is not None:
-                    try:
-                        os.chmod(xlsx_path, original_mode)
-                    except Exception as ex:
-                        logger.debug(f"Failed to restore original permissions of {xlsx_path}: {ex}")
-            except Exception:
-                if os.path.exists(temp_xlsx_path):
-                    os.remove(temp_xlsx_path)
-                raise
-    except Exception as ex:
-        logger.debug(f"Failed to hide sheet {sheet_name}: {ex}")
 
 
 def _normalize_merge_text(value: str) -> str:

--- a/src/fosslight_source/_merge.py
+++ b/src/fosslight_source/_merge.py
@@ -32,12 +32,29 @@ def _normalize_merge_text(value: str) -> str:
     return value.strip() if value else ""
 
 
+def _get_item_oss_name(item: SourceItem) -> str:
+    if item.oss_items:
+        return item.oss_items[0].name
+    return item.oss_name
+
+
+def _get_item_oss_version(item: SourceItem) -> str:
+    if item.oss_items:
+        return item.oss_items[0].version
+    return item.oss_version
+
+
 def _get_merge_licenses(scan_item: SourceItem) -> tuple:
+    if scan_item.oss_items:
+        return tuple(sorted([lic.strip() for lic in scan_item.oss_items[0].license if lic and lic.strip()]))
     return tuple(sorted([lic.strip() for lic in scan_item.licenses if lic and lic.strip()]))
 
 
 def _get_merge_download_locations(scan_item: SourceItem) -> tuple:
-    downloads = scan_item.download_location
+    if scan_item.oss_items:
+        downloads = scan_item.oss_items[0].download_location
+    else:
+        downloads = scan_item.download_location
     if not downloads:
         return ()
     if isinstance(downloads, str):
@@ -81,10 +98,15 @@ def _get_top_merge_values(scan_items: list, value_getter) -> list:
 
 
 def _can_merge_folder(scan_items: list) -> bool:
+    if len(scan_items) <= 1:
+        return False
+    # If any file has multiple OSS components, do not merge this folder
+    for item in scan_items:
+        if len(item.oss_items) > 1:
+            return False
     return (
-        len(scan_items) > 1
-        and _is_merge_field_compatible(scan_items, lambda item: _normalize_merge_text(item.oss_name))
-        and _is_merge_field_compatible(scan_items, lambda item: _normalize_merge_text(item.oss_version))
+        _is_merge_field_compatible(scan_items, lambda item: _normalize_merge_text(_get_item_oss_name(item)))
+        and _is_merge_field_compatible(scan_items, lambda item: _normalize_merge_text(_get_item_oss_version(item)))
         and _is_merge_field_compatible(scan_items, _get_merge_licenses)
         and _is_merge_field_compatible(scan_items, _get_merge_download_locations)
     )
@@ -106,12 +128,11 @@ def _get_merged_comments(scan_items: list) -> str:
 
 
 def _create_merged_item(scan_items: list, merge_path: str) -> SourceItem:
-    # Reuse the shortest path item as the representative row, but keep original paths untouched.
-    representative_item = min(scan_items, key=lambda item: (len(item.source_name_or_path), item.source_name_or_path))
+    representative_item = scan_items[0]
     merged_item = copy.copy(representative_item)
     merged_item.source_name_or_path = f"{merge_path} ({len(scan_items)})"
-    merged_item.oss_name = _get_merge_field_value(scan_items, lambda item: _normalize_merge_text(item.oss_name))
-    merged_item.oss_version = _get_merge_field_value(scan_items, lambda item: _normalize_merge_text(item.oss_version))
+    merged_item.oss_name = _get_merge_field_value(scan_items, lambda item: _normalize_merge_text(_get_item_oss_name(item)))
+    merged_item.oss_version = _get_merge_field_value(scan_items, lambda item: _normalize_merge_text(_get_item_oss_version(item)))
     merged_item._licenses = []
     merged_item.licenses = list(_get_merge_field_value(scan_items, _get_merge_licenses))
     merged_downloads = _get_merge_field_value(scan_items, _get_merge_download_locations)
@@ -121,7 +142,6 @@ def _create_merged_item(scan_items: list, merge_path: str) -> SourceItem:
     merged_item._comment = _get_merged_comments(scan_items)
     merged_item.set_oss_item()
     return merged_item
-
 
 
 def merge_results_by_folder(scan_result: list) -> list:
@@ -145,6 +165,12 @@ def merge_results_by_folder(scan_result: list) -> list:
             current_node = current_node["children"].setdefault(folder_name, {"items": [], "children": {}})
         current_node["items"].append(scan_item)
 
+    def get_all_eligible_items(node: dict) -> list:
+        items = [item for item in node["items"] if not item.exclude]
+        for child_node in node["children"].values():
+            items.extend(get_all_eligible_items(child_node))
+        return items
+
     def merge_node(merge_node_item: dict, merge_path: str = "", depth: int = 0) -> tuple:
         child_finalized = []
         child_unfinalized = []
@@ -166,7 +192,8 @@ def merge_results_by_folder(scan_result: list) -> list:
         can_merge_here = (depth > 0) and (len(local_eligible) + len(child_unfinalized) > 1)
 
         if can_merge_here:
-            if _can_merge_folder(all_eligible_candidates):
+            all_subtree_eligible = get_all_eligible_items(merge_node_item)
+            if _can_merge_folder(all_subtree_eligible):
                 new_finalized = child_finalized + local_excluded
                 new_unfinalized = [(merge_path, all_eligible_candidates)]
                 return new_finalized, new_unfinalized
@@ -200,7 +227,7 @@ def merge_results_by_folder(scan_result: list) -> list:
     fin, unfin = merge_node(merge_tree)
     finalized_results = list(fin)
     for path, items in unfin:
-        if len(items) > 1 and _can_merge_folder(items):
+        if path and len(items) > 1 and _can_merge_folder(items):
             finalized_results.append(_create_merged_item(items, path))
         else:
             finalized_results.extend(items)

--- a/src/fosslight_source/_merge.py
+++ b/src/fosslight_source/_merge.py
@@ -74,6 +74,14 @@ def _hide_xlsx_sheet(xlsx_path: str, sheet_name: str) -> None:
             updated_workbook_xml = ET.tostring(root, encoding="utf-8", xml_declaration=True)
 
             output_dir = os.path.dirname(xlsx_path) or "."
+
+            original_mode = None
+            if os.path.exists(xlsx_path):
+                try:
+                    original_mode = os.stat(xlsx_path).st_mode
+                except Exception as ex:
+                    logger.debug(f"Failed to capture original permissions of {xlsx_path}: {ex}")
+
             with tempfile.NamedTemporaryFile(delete=False, dir=output_dir, suffix=".xlsx") as temp_file:
                 temp_xlsx_path = temp_file.name
 
@@ -86,6 +94,12 @@ def _hide_xlsx_sheet(xlsx_path: str, sheet_name: str) -> None:
                             content = workbook.read(item.filename)
                         updated_workbook.writestr(item, content)
                 shutil.move(temp_xlsx_path, xlsx_path)
+
+                if original_mode is not None:
+                    try:
+                        os.chmod(xlsx_path, original_mode)
+                    except Exception as ex:
+                        logger.debug(f"Failed to restore original permissions of {xlsx_path}: {ex}")
             except Exception:
                 if os.path.exists(temp_xlsx_path):
                     os.remove(temp_xlsx_path)

--- a/src/fosslight_source/_merge.py
+++ b/src/fosslight_source/_merge.py
@@ -101,11 +101,7 @@ def _get_merged_comments(scan_items: list) -> str:
         return ""
 
     delimiter = " / "
-    merged = delimiter.join(comments)
-    max_len = 32767
-    if len(merged) > max_len:
-        merged = merged[:max_len - 3] + "..."
-    return merged
+    return delimiter.join(comments)
 
 
 def _create_merged_item(scan_items: list, merge_path: str) -> SourceItem:

--- a/src/fosslight_source/_merge.py
+++ b/src/fosslight_source/_merge.py
@@ -7,6 +7,8 @@ import os
 import copy
 from collections import Counter
 
+from fosslight_util.constant import COMMENT_DELIMITER
+
 from ._scan_item import SourceItem
 
 
@@ -93,15 +95,14 @@ def _get_merged_comments(scan_items: list) -> str:
     for item in scan_items:
         val = item.comment
         if val:
-            parts = [p.strip() for p in val.split(" / ") if p.strip()]
+            parts = [p.strip() for p in val.split(COMMENT_DELIMITER) if p.strip()]
             for p in parts:
                 if p not in comments:
                     comments.append(p)
     if not comments:
         return ""
 
-    delimiter = " / "
-    return delimiter.join(comments)
+    return COMMENT_DELIMITER.join(comments)
 
 
 def _create_merged_item(scan_items: list, merge_path: str) -> SourceItem:
@@ -124,7 +125,12 @@ def _create_merged_item(scan_items: list, merge_path: str) -> SourceItem:
 
 def merge_results_by_folder(scan_result: list) -> list:
     """
-    Merge output rows within the same folder when OSS name, OSS version, and license are compatible.
+    Merge output rows within the same folder when OSS name, OSS version, license,
+    and download location are compatible.
+
+    A field is compatible when non-empty values across rows differ by at most one
+    (empty values are ignored). All eligible rows in the folder must be compatible
+    together; rows are not grouped by key subsets.
     """
     # Build a folder tree first so merge never jumps straight to root ".".
     merge_tree = {"items": [], "children": {}}

--- a/src/fosslight_source/_merge.py
+++ b/src/fosslight_source/_merge.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
-import copy
 from collections import Counter
 
 from fosslight_util.constant import COMMENT_DELIMITER
@@ -169,19 +168,19 @@ def _get_merged_comments(scan_items: list) -> str:
 
 
 def _create_merged_item(scan_items: list, merge_path: str) -> SourceItem:
-    representative_item = scan_items[0]
-    merged_item = copy.copy(representative_item)
-    merged_item.source_name_or_path = f"{merge_path} ({len(scan_items)})"
+    merged_path = f"{merge_path} ({len(scan_items)})"
+    merged_item = SourceItem(merged_path)
     merged_item.oss_name = _get_merge_field_value(scan_items, lambda item: _normalize_merge_text(_get_item_oss_name(item)))
     merged_item.oss_version = _get_merge_field_value(scan_items, lambda item: _normalize_merge_text(_get_item_oss_version(item)))
-    merged_item._licenses = []
     merged_licenses = _get_merge_field_value(scan_items, _get_merge_licenses)
     merged_item.licenses = list(merged_licenses) if merged_licenses else []
     merged_downloads = _get_merge_field_value(scan_items, _get_merge_download_locations)
     merged_item.download_location = list(merged_downloads) if merged_downloads else []
     merged_copyrights = _get_top_merge_values(scan_items, lambda item: item.copyright)
     merged_item.copyright = merged_copyrights if merged_copyrights else []
-    merged_item._comment = _get_merged_comments(scan_items)
+    merged_comments = _get_merged_comments(scan_items)
+    if merged_comments:
+        merged_item.comment = merged_comments
     merged_item.set_oss_item()
     return merged_item
 

--- a/src/fosslight_source/_merge.py
+++ b/src/fosslight_source/_merge.py
@@ -123,6 +123,7 @@ def _create_merged_item(scan_items: list, merge_path: str) -> SourceItem:
     return merged_item
 
 
+
 def merge_results_by_folder(scan_result: list) -> list:
     """
     Merge output rows within the same folder when OSS name, OSS version, license,
@@ -144,19 +145,64 @@ def merge_results_by_folder(scan_result: list) -> list:
             current_node = current_node["children"].setdefault(folder_name, {"items": [], "children": {}})
         current_node["items"].append(scan_item)
 
-    def merge_node(merge_node_item: dict, merge_path: str = "", depth: int = 0) -> list:
-        excluded_items = [item for item in merge_node_item["items"] if item.exclude]
-        eligible_items = [item for item in merge_node_item["items"] if not item.exclude]
-
-        # Keep at least one path depth in the report; root-level ". (N)" is too broad.
-        if depth > 0 and _can_merge_folder(eligible_items):
-            merged_items = [_create_merged_item(eligible_items, merge_path)] + excluded_items
-        else:
-            merged_items = list(merge_node_item["items"])
-
+    def merge_node(merge_node_item: dict, merge_path: str = "", depth: int = 0) -> tuple:
+        child_finalized = []
+        child_unfinalized = []
         for folder_name, child_node in merge_node_item["children"].items():
             child_path = f"{merge_path}/{folder_name}" if merge_path else folder_name
-            merged_items.extend(merge_node(child_node, child_path, depth + 1))
-        return merged_items
+            fin, unfin = merge_node(child_node, child_path, depth + 1)
+            child_finalized.extend(fin)
+            child_unfinalized.extend(unfin)
 
-    return merge_node(merge_tree)
+        local_excluded = [item for item in merge_node_item["items"] if item.exclude]
+        local_eligible = [item for item in merge_node_item["items"] if not item.exclude]
+
+        all_eligible_candidates = list(local_eligible)
+        for _, g_items in child_unfinalized:
+            all_eligible_candidates.extend(g_items)
+
+        # We can merge under the current node if depth > 0 and we are combining multiple sources:
+        # e.g., local files + child groups, or multiple child groups, or multiple local files.
+        can_merge_here = (depth > 0) and (len(local_eligible) + len(child_unfinalized) > 1)
+
+        if can_merge_here:
+            if _can_merge_folder(all_eligible_candidates):
+                new_finalized = child_finalized + local_excluded
+                new_unfinalized = [(merge_path, all_eligible_candidates)]
+                return new_finalized, new_unfinalized
+            else:
+                # Compatibility broke at this level. We must finalize the subtrees.
+                finalized_child_groups = []
+                for c_path, c_items in child_unfinalized:
+                    if len(c_items) > 1 and _can_merge_folder(c_items):
+                        finalized_child_groups.append(_create_merged_item(c_items, c_path))
+                    else:
+                        finalized_child_groups.extend(c_items)
+
+                finalized_local = []
+                if len(local_eligible) > 1 and _can_merge_folder(local_eligible):
+                    finalized_local.append(_create_merged_item(local_eligible, merge_path))
+                else:
+                    finalized_local.extend(local_eligible)
+
+                new_finalized = child_finalized + local_excluded + finalized_child_groups + finalized_local
+                new_unfinalized = []
+                return new_finalized, new_unfinalized
+        else:
+            # We cannot merge or don't need to merge at this level (e.g. depth == 0 or only 1 source).
+            # We propagate everything up as unfinalized.
+            new_finalized = child_finalized + local_excluded
+            new_unfinalized = list(child_unfinalized)
+            if local_eligible:
+                new_unfinalized.append((merge_path, local_eligible))
+            return new_finalized, new_unfinalized
+
+    fin, unfin = merge_node(merge_tree)
+    finalized_results = list(fin)
+    for path, items in unfin:
+        if len(items) > 1 and _can_merge_folder(items):
+            finalized_results.append(_create_merged_item(items, path))
+        else:
+            finalized_results.extend(items)
+
+    return finalized_results

--- a/src/fosslight_source/_merge.py
+++ b/src/fosslight_source/_merge.py
@@ -186,7 +186,6 @@ def merge_results_by_folder(scan_result: list) -> list:
             current_node = current_node["children"].setdefault(folder_name, {"items": [], "children": {}})
         current_node["items"].append(scan_item)
 
-
     def merge_node(merge_node_item: dict, merge_path: str = "", depth: int = 0) -> tuple:
         child_finalized = []
         child_unfinalized = []

--- a/src/fosslight_source/_merge.py
+++ b/src/fosslight_source/_merge.py
@@ -8,16 +8,6 @@ import copy
 from collections import Counter
 
 from ._scan_item import SourceItem
-from fosslight_util.oss_item import ScannerItem
-
-PKG_NAME = "fosslight_source"
-SRC_SHEET_NAME = 'SRC_FL_Source'
-PRE_MERGE_SHEET_NAME = '.SRC_FL_Source_no_merge'
-
-MERGED_HEADER = {SRC_SHEET_NAME: ['ID', 'Source Path', 'OSS Name',
-                                  'OSS Version', 'License', 'Download Location',
-                                  'Homepage', 'Copyright Text', 'Exclude', 'Comment', 'license_reference']}
-
 
 def _get_source_rows_to_print(source_items: list) -> list:
     source_rows = []
@@ -26,11 +16,11 @@ def _get_source_rows_to_print(source_items: list) -> list:
     return source_rows
 
 
-def _add_pre_merge_sheet(scan_item: 'ScannerItem') -> None:
+def _add_pre_merge_sheet(scan_item, pre_merge_sheet_name: str, header_row: list, pkg_name: str) -> None:
     external_sheets = getattr(scan_item, "external_sheets", {}) or {}
-    external_sheets[PRE_MERGE_SHEET_NAME] = [
-        MERGED_HEADER[SRC_SHEET_NAME],
-        *_get_source_rows_to_print(scan_item.file_items.get(PKG_NAME, [])),
+    external_sheets[pre_merge_sheet_name] = [
+        header_row,
+        *_get_source_rows_to_print(scan_item.file_items.get(pkg_name, [])),
     ]
     scan_item.external_sheets = external_sheets
 

--- a/src/fosslight_source/_scan_item.py
+++ b/src/fosslight_source/_scan_item.py
@@ -48,7 +48,6 @@ class SourceItem(FileItem):
         self.source_name_or_path = value
         self.is_license_text = False
         self.is_manifest_file = False
-        self.license_reference = ""
         self.scanoss_reference = {}
         self.matched_lines = ""  # Only for SCANOSS results
         self.fileURL = ""  # Only for SCANOSS results
@@ -206,8 +205,7 @@ class SourceItem(FileItem):
         for item in self.oss_items:
             print_rows.append([self.source_name_or_path, item.name, item.version, ",".join(item.license),
                                item.download_location, "",
-                               item.copyright, "Exclude" if self.exclude else "", item.comment,
-                               self.license_reference])
+                               item.copyright, "Exclude" if self.exclude else "", item.comment])
         return print_rows
 
     def __eq__(self, other: object) -> bool:

--- a/src/fosslight_source/cli.py
+++ b/src/fosslight_source/cli.py
@@ -44,7 +44,7 @@ import shutil
 
 
 SRC_SHEET_NAME = 'SRC_FL_Source'
-PRE_MERGE_SHEET_NAME = 'SRC_FL_Source_before_merge'
+PRE_MERGE_SHEET_NAME = '.SRC_FL_Source_no_merge'
 SCANOSS_HEADER = {SRC_SHEET_NAME: ['ID', 'Source Path', 'OSS Name',
                                    'OSS Version', 'License', 'Download Location',
                                    'Homepage', 'Copyright Text', 'Exclude', 'Comment']}
@@ -643,10 +643,10 @@ def _create_merged_item(scan_items: list, merge_path: str) -> SourceItem:
     merged_item.oss_version = _get_merge_field_value(scan_items, lambda item: _normalize_merge_text(item.oss_version))
     merged_item._licenses = []
     merged_item.licenses = list(_get_merge_field_value(scan_items, _get_merge_licenses))
-    merged_downloads = _get_top_merge_values(scan_items, lambda item: item.download_location)
+    merged_downloads = _get_merge_field_value(scan_items, _get_merge_download_locations)
+    merged_item.download_location = list(merged_downloads) if merged_downloads else []
     merged_copyrights = _get_top_merge_values(scan_items, lambda item: item.copyright)
-    merged_item.download_location = [", ".join(merged_downloads)] if merged_downloads else []
-    merged_item.copyright = [", ".join(merged_copyrights)] if merged_copyrights else []
+    merged_item.copyright = merged_copyrights if merged_copyrights else []
     merged_item.set_oss_item(run_kb=False)
     return merged_item
 

--- a/src/fosslight_source/cli.py
+++ b/src/fosslight_source/cli.py
@@ -131,11 +131,13 @@ def main() -> None:
 
     if os.path.isdir(path_to_scan):
         result = []
+        _total_start = time.time()
         result = run_scanners(path_to_scan, output_file_name, write_json_file, core, True,
                               print_matched_text, formats, time_out, correct_mode, correct_filepath,
                               selected_scanner, path_to_exclude, hide_progress=hide_progress,
                               kb_url=kb_url, kb_token=kb_token,
                               merge_by_folder=merge_by_folder)
+        logger.info(f"[TIMING] run_scanners total: {time.time() - _total_start:.4f}s")
 
         _result_log["Scan Result"] = result[1]
 
@@ -268,7 +270,9 @@ def create_report_file(
 
     if merged_result and merge_by_folder:
         _add_pre_merge_sheet(scan_item, PRE_MERGE_SHEET_NAME, MERGED_HEADER[SRC_SHEET_NAME], PKG_NAME)
+        _merge_start = time.time()
         scan_item.file_items[PKG_NAME] = merge_results_by_folder(scan_item.file_items[PKG_NAME])
+        logger.info(f"[TIMING] merge_results_by_folder: {time.time() - _merge_start:.4f}s")
 
     combined_paths_and_files = [os.path.join(output_path, file) for file in output_files]
     results = []

--- a/src/fosslight_source/cli.py
+++ b/src/fosslight_source/cli.py
@@ -14,7 +14,7 @@ import urllib.request
 import urllib.error
 import tempfile
 import zipfile
-import xml.etree.ElementTree as ET
+import defusedxml.ElementTree as ET
 from datetime import datetime
 import fosslight_util.constant as constant
 from fosslight_util.set_log import init_log
@@ -223,7 +223,7 @@ def create_report_file(
     output_extensions: list = [], correct_mode: bool = True,
     correct_filepath: str = "", path_to_scan: str = "", path_to_exclude: list = [],
     formats: list = [], api_limit_exceed: bool = False, files_count: int = 0, final_output_path: str = "",
-    run_kb_msg: str = "", merge_by_folder: bool = False, kb_reference_result: list = None
+    run_kb_msg: str = "", merge_by_folder: bool = False, kb_reference_result: Optional[list] = None
 ) -> 'ScannerItem':
     """
     Create report files for given scanned result.
@@ -576,7 +576,7 @@ def _normalize_merge_text(value: str) -> str:
 
 
 def _get_merge_licenses(scan_item: SourceItem) -> tuple:
-    return tuple(sorted([license.strip() for license in scan_item.licenses if license and license.strip()]))
+    return tuple(sorted([lic.strip() for lic in scan_item.licenses if lic and lic.strip()]))
 
 
 def _get_merge_field_value(scan_items: list, value_getter) -> str:

--- a/src/fosslight_source/cli.py
+++ b/src/fosslight_source/cli.py
@@ -155,7 +155,7 @@ def create_report_file(
     output_extensions: list = [], correct_mode: bool = True,
     correct_filepath: str = "", path_to_scan: str = "", path_to_exclude: list = [],
     formats: list = [], api_limit_exceed: bool = False, files_count: int = 0, final_output_path: str = "",
-    run_kb_msg: str = "", merge_by_folder: bool = False
+    run_kb_msg: str = "", merge_by_folder: bool = True
 ) -> 'ScannerItem':
     """
     Create report files for given scanned result.

--- a/src/fosslight_source/cli.py
+++ b/src/fosslight_source/cli.py
@@ -580,6 +580,15 @@ def _get_merge_licenses(scan_item: SourceItem) -> tuple:
     return tuple(sorted([lic.strip() for lic in scan_item.licenses if lic and lic.strip()]))
 
 
+def _get_merge_download_locations(scan_item: SourceItem) -> tuple:
+    downloads = scan_item.download_location
+    if not downloads:
+        return ()
+    if isinstance(downloads, str):
+        downloads = [downloads]
+    return tuple(sorted([dl.strip() for dl in downloads if dl and dl.strip()]))
+
+
 def _get_merge_field_value(scan_items: list, value_getter) -> str:
     for scan_item in scan_items:
         value = value_getter(scan_item)
@@ -618,10 +627,10 @@ def _get_top_merge_values(scan_items: list, value_getter) -> list:
 def _can_merge_folder(scan_items: list) -> bool:
     return (
         len(scan_items) > 1
-        and len({bool(item.exclude) for item in scan_items}) <= 1
         and _is_merge_field_compatible(scan_items, lambda item: _normalize_merge_text(item.oss_name))
         and _is_merge_field_compatible(scan_items, lambda item: _normalize_merge_text(item.oss_version))
         and _is_merge_field_compatible(scan_items, _get_merge_licenses)
+        and _is_merge_field_compatible(scan_items, _get_merge_download_locations)
     )
 
 
@@ -659,9 +668,12 @@ def merge_results_by_folder(scan_result: list) -> list:
         current_node["items"].append(scan_item)
 
     def merge_node(merge_node_item: dict, merge_path: str = "", depth: int = 0) -> list:
+        excluded_items = [item for item in merge_node_item["items"] if item.exclude]
+        eligible_items = [item for item in merge_node_item["items"] if not item.exclude]
+
         # Keep at least one path depth in the report; root-level ". (N)" is too broad.
-        if depth > 0 and _can_merge_folder(merge_node_item["items"]):
-            merged_items = [_create_merged_item(merge_node_item["items"], merge_path)]
+        if depth > 0 and _can_merge_folder(eligible_items):
+            merged_items = [_create_merged_item(eligible_items, merge_path)] + excluded_items
         else:
             merged_items = list(merge_node_item["items"])
 

--- a/src/fosslight_source/cli.py
+++ b/src/fosslight_source/cli.py
@@ -18,6 +18,7 @@ from fosslight_util.set_log import init_log
 from ._help import print_version, print_help_msg_source_scanner
 from ._license_matched import get_license_list_to_print
 from fosslight_util.output_format import check_output_formats_v2, write_output_file
+from fosslight_util.write_excel import get_header_row
 from fosslight_util.correct import correct_with_yaml
 from fosslight_util.parsing_yaml import SUPPORT_OSS_INFO_FILES
 from .run_scancode import run_scan
@@ -43,12 +44,6 @@ from ._merge import (
 
 SRC_SHEET_NAME = 'SRC_FL_Source'
 PRE_MERGE_SHEET_NAME = '.SRC_FL_Source_no_merge'
-SCANOSS_HEADER = {SRC_SHEET_NAME: ['ID', 'Source Path', 'OSS Name',
-                                   'OSS Version', 'License', 'Download Location',
-                                   'Homepage', 'Copyright Text', 'Exclude', 'Comment']}
-MERGED_HEADER = {SRC_SHEET_NAME: ['ID', 'Source Path', 'OSS Name',
-                                  'OSS Version', 'License', 'Download Location',
-                                  'Homepage', 'Copyright Text', 'Exclude', 'Comment', 'license_reference']}
 KB_REFERENCE_HEADER = ['ID', 'Source Path', 'KB Origin URL', 'Evidence']
 ALL_MODE = 'all'
 SCANNER_TYPE = ['kb', 'scancode', 'scanoss', ALL_MODE]
@@ -235,11 +230,6 @@ def create_report_file(
         sheet_list = {}
         scan_item.append_file_items(merged_result, PKG_NAME)
 
-        if selected_scanner == 'scanoss':
-            extended_header = SCANOSS_HEADER
-        else:
-            extended_header = MERGED_HEADER
-
         if need_license:
             if selected_scanner == 'scancode':
                 sheet_list["scancode_reference"] = get_license_list_to_print(license_list)
@@ -266,7 +256,7 @@ def create_report_file(
             logger.info("Success to correct with yaml.")
 
     if merged_result and merge_by_folder:
-        _add_pre_merge_sheet(scan_item, PRE_MERGE_SHEET_NAME, extended_header[SRC_SHEET_NAME], PKG_NAME)
+        _add_pre_merge_sheet(scan_item, PRE_MERGE_SHEET_NAME, get_header_row(SRC_SHEET_NAME), PKG_NAME)
         _merge_start = time.time()
         scan_item.file_items[PKG_NAME] = merge_results_by_folder(scan_item.file_items[PKG_NAME])
         logger.debug(f"[TIMING] merge_results_by_folder: {time.time() - _merge_start:.4f}s")

--- a/src/fosslight_source/cli.py
+++ b/src/fosslight_source/cli.py
@@ -561,6 +561,11 @@ def run_scanners(
             print_matched_text = False
 
         if success:
+            has_sbom_format = any(f.startswith('spdx') or f.startswith('cyclonedx') for f in formats) if formats else False
+            if has_sbom_format and merge_by_folder:
+                logger.info("SPDX/CycloneDX format does not support merge. Merging is not performed.")
+                merge_by_folder = False
+
             if all_exclude_mode and len(all_exclude_mode) == 4:
                 (excluded_path_with_default_exclusion,
                  excluded_path_without_dot,

--- a/src/fosslight_source/cli.py
+++ b/src/fosslight_source/cli.py
@@ -36,10 +36,8 @@ from typing import Optional, Tuple
 from ._scan_item import is_manifest_file
 import shutil
 from ._merge import (
-    PRE_MERGE_SHEET_NAME,
     MERGED_HEADER,
     _add_pre_merge_sheet,
-    _hide_xlsx_sheet,
     merge_results_by_folder
 )
 
@@ -271,16 +269,12 @@ def create_report_file(
 
     combined_paths_and_files = [os.path.join(output_path, file) for file in output_files]
     results = []
-    has_pre_merge_sheet = PRE_MERGE_SHEET_NAME in getattr(scan_item, "external_sheets", {})
     for combined_path_and_file, output_extension, output_format in zip(combined_paths_and_files, output_extensions, formats):
         # if need_license and output_extension == _json_ext and "scanoss_reference" in sheet_list:
         #     del sheet_list["scanoss_reference"]
         result = write_output_file(
             combined_path_and_file, output_extension, scan_item, extended_header, "", output_format
         )
-        success, _, result_file = result
-        if success and has_pre_merge_sheet and result_file.endswith(".xlsx"):
-            _hide_xlsx_sheet(result_file, PRE_MERGE_SHEET_NAME)
         results.append(result)
     for success, msg, result_file in results:
         final_result_file = result_file.replace(output_path, final_output_path)

--- a/src/fosslight_source/cli.py
+++ b/src/fosslight_source/cli.py
@@ -15,6 +15,7 @@ import urllib.error
 import tempfile
 import zipfile
 import defusedxml.ElementTree as ET
+import xml.etree.ElementTree as xmlET
 from datetime import datetime
 import fosslight_util.constant as constant
 from fosslight_util.set_log import init_log
@@ -82,8 +83,8 @@ def _hide_xlsx_sheet(xlsx_path: str, sheet_name: str) -> None:
     workbook_xml_path = "xl/workbook.xml"
     namespace_uri = "http://schemas.openxmlformats.org/spreadsheetml/2006/main"
     relationship_uri = "http://schemas.openxmlformats.org/officeDocument/2006/relationships"
-    ET.register_namespace("", namespace_uri)
-    ET.register_namespace("r", relationship_uri)
+    xmlET.register_namespace("", namespace_uri)
+    xmlET.register_namespace("r", relationship_uri)
 
     try:
         with zipfile.ZipFile(xlsx_path, "r") as workbook:

--- a/src/fosslight_source/cli.py
+++ b/src/fosslight_source/cli.py
@@ -12,6 +12,9 @@ import logging
 import re
 import urllib.request
 import urllib.error
+import tempfile
+import zipfile
+import xml.etree.ElementTree as ET
 from datetime import datetime
 import fosslight_util.constant as constant
 from fosslight_util.set_log import init_log
@@ -40,6 +43,7 @@ import shutil
 
 
 SRC_SHEET_NAME = 'SRC_FL_Source'
+PRE_MERGE_SHEET_NAME = 'SRC_FL_Source_before_merge'
 SCANOSS_HEADER = {SRC_SHEET_NAME: ['ID', 'Source Path', 'OSS Name',
                                    'OSS Version', 'License', 'Download Location',
                                    'Homepage', 'Copyright Text', 'Exclude', 'Comment']}
@@ -56,6 +60,72 @@ logger = logging.getLogger(constant.LOGGER_NAME)
 warnings.filterwarnings("ignore", category=FutureWarning)
 PKG_NAME = "fosslight_source"
 RESULT_KEY = "Scan Result"
+
+
+def _get_source_rows_to_print(source_items: list) -> list:
+    source_rows = []
+    for source_item in source_items:
+        source_rows.extend(source_item.get_print_array())
+    return source_rows
+
+
+def _add_pre_merge_sheet(scan_item: 'ScannerItem') -> None:
+    external_sheets = getattr(scan_item, "external_sheets", {}) or {}
+    external_sheets[PRE_MERGE_SHEET_NAME] = [
+        MERGED_HEADER[SRC_SHEET_NAME],
+        *_get_source_rows_to_print(scan_item.file_items.get(PKG_NAME, [])),
+    ]
+    scan_item.external_sheets = external_sheets
+
+
+def _hide_xlsx_sheet(xlsx_path: str, sheet_name: str) -> None:
+    workbook_xml_path = "xl/workbook.xml"
+    namespace_uri = "http://schemas.openxmlformats.org/spreadsheetml/2006/main"
+    relationship_uri = "http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+    ET.register_namespace("", namespace_uri)
+    ET.register_namespace("r", relationship_uri)
+
+    try:
+        with zipfile.ZipFile(xlsx_path, "r") as workbook:
+            try:
+                workbook_xml = workbook.read(workbook_xml_path)
+            except KeyError:
+                logger.debug(f"Failed to hide sheet. workbook.xml not found: {xlsx_path}")
+                return
+
+            root = ET.fromstring(workbook_xml)
+            target_sheet = None
+            for sheet in root.findall(f".//{{{namespace_uri}}}sheet"):
+                if sheet.attrib.get("name") == sheet_name:
+                    target_sheet = sheet
+                    break
+
+            if target_sheet is None:
+                logger.debug(f"Failed to hide sheet. sheet not found: {sheet_name}")
+                return
+
+            target_sheet.set("state", "hidden")
+            updated_workbook_xml = ET.tostring(root, encoding="utf-8", xml_declaration=True)
+
+            output_dir = os.path.dirname(xlsx_path) or "."
+            with tempfile.NamedTemporaryFile(delete=False, dir=output_dir, suffix=".xlsx") as temp_file:
+                temp_xlsx_path = temp_file.name
+
+            try:
+                with zipfile.ZipFile(temp_xlsx_path, "w") as updated_workbook:
+                    for item in workbook.infolist():
+                        if item.filename == workbook_xml_path:
+                            content = updated_workbook_xml
+                        else:
+                            content = workbook.read(item.filename)
+                        updated_workbook.writestr(item, content)
+                shutil.move(temp_xlsx_path, xlsx_path)
+            except Exception:
+                if os.path.exists(temp_xlsx_path):
+                    os.remove(temp_xlsx_path)
+                raise
+    except Exception as ex:
+        logger.debug(f"Failed to hide sheet {sheet_name}: {ex}")
 
 
 def main() -> None:
@@ -264,14 +334,22 @@ def create_report_file(
             logger.info("Success to correct with yaml.")
 
     if merged_result and merge_by_folder:
+        _add_pre_merge_sheet(scan_item)
         scan_item.file_items[PKG_NAME] = merge_results_by_folder(scan_item.file_items[PKG_NAME])
 
     combined_paths_and_files = [os.path.join(output_path, file) for file in output_files]
     results = []
+    has_pre_merge_sheet = PRE_MERGE_SHEET_NAME in getattr(scan_item, "external_sheets", {})
     for combined_path_and_file, output_extension, output_format in zip(combined_paths_and_files, output_extensions, formats):
         # if need_license and output_extension == _json_ext and "scanoss_reference" in sheet_list:
         #     del sheet_list["scanoss_reference"]
-        results.append(write_output_file(combined_path_and_file, output_extension, scan_item, extended_header, "", output_format))
+        result = write_output_file(
+            combined_path_and_file, output_extension, scan_item, extended_header, "", output_format
+        )
+        success, _, result_file = result
+        if success and has_pre_merge_sheet and result_file.endswith(".xlsx"):
+            _hide_xlsx_sheet(result_file, PRE_MERGE_SHEET_NAME)
+        results.append(result)
     for success, msg, result_file in results:
         final_result_file = result_file.replace(output_path, final_output_path)
         if success:

--- a/src/fosslight_source/cli.py
+++ b/src/fosslight_source/cli.py
@@ -36,16 +36,19 @@ from typing import Optional, Tuple
 from ._scan_item import is_manifest_file
 import shutil
 from ._merge import (
-    MERGED_HEADER,
     _add_pre_merge_sheet,
     merge_results_by_folder
 )
 
 
 SRC_SHEET_NAME = 'SRC_FL_Source'
+PRE_MERGE_SHEET_NAME = '.SRC_FL_Source_no_merge'
 SCANOSS_HEADER = {SRC_SHEET_NAME: ['ID', 'Source Path', 'OSS Name',
                                    'OSS Version', 'License', 'Download Location',
                                    'Homepage', 'Copyright Text', 'Exclude', 'Comment']}
+MERGED_HEADER = {SRC_SHEET_NAME: ['ID', 'Source Path', 'OSS Name',
+                                  'OSS Version', 'License', 'Download Location',
+                                  'Homepage', 'Copyright Text', 'Exclude', 'Comment', 'license_reference']}
 KB_REFERENCE_HEADER = ['ID', 'Source Path', 'KB Origin URL', 'Evidence']
 ALL_MODE = 'all'
 SCANNER_TYPE = ['kb', 'scancode', 'scanoss', ALL_MODE]
@@ -264,7 +267,7 @@ def create_report_file(
             logger.info("Success to correct with yaml.")
 
     if merged_result and merge_by_folder:
-        _add_pre_merge_sheet(scan_item)
+        _add_pre_merge_sheet(scan_item, PRE_MERGE_SHEET_NAME, MERGED_HEADER[SRC_SHEET_NAME], PKG_NAME)
         scan_item.file_items[PKG_NAME] = merge_results_by_folder(scan_item.file_items[PKG_NAME])
 
     combined_paths_and_files = [os.path.join(output_path, file) for file in output_files]

--- a/src/fosslight_source/cli.py
+++ b/src/fosslight_source/cli.py
@@ -266,7 +266,7 @@ def create_report_file(
             logger.info("Success to correct with yaml.")
 
     if merged_result and merge_by_folder:
-        _add_pre_merge_sheet(scan_item, PRE_MERGE_SHEET_NAME, MERGED_HEADER[SRC_SHEET_NAME], PKG_NAME)
+        _add_pre_merge_sheet(scan_item, PRE_MERGE_SHEET_NAME, extended_header[SRC_SHEET_NAME], PKG_NAME)
         _merge_start = time.time()
         scan_item.file_items[PKG_NAME] = merge_results_by_folder(scan_item.file_items[PKG_NAME])
         logger.debug(f"[TIMING] merge_results_by_folder: {time.time() - _merge_start:.4f}s")

--- a/src/fosslight_source/cli.py
+++ b/src/fosslight_source/cli.py
@@ -27,6 +27,8 @@ from .run_scanoss import get_scanoss_extra_info
 import yaml
 import tqdm
 import argparse
+import copy
+from collections import Counter
 from .run_spdx_extractor import get_spdx_downloads
 from .run_manifest_extractor import get_manifest_licenses
 from ._scan_item import SourceItem, resolve_kb_config, is_notice_file
@@ -88,6 +90,7 @@ def main() -> None:
     parser.add_argument('--hide_progress', action='store_true', required=False)
     parser.add_argument('--kb_url', type=str, required=False, default="")
     parser.add_argument('--kb_token', type=str, required=False, default="")
+    parser.add_argument('--no_merge', action='store_true', required=False)
 
     args = parser.parse_args()
 
@@ -118,6 +121,7 @@ def main() -> None:
     hide_progress = args.hide_progress
     kb_url = args.kb_url
     kb_token = args.kb_token
+    merge_by_folder = not args.no_merge
 
     time_out = args.timeout
     core = args.cores
@@ -127,7 +131,8 @@ def main() -> None:
         result = run_scanners(path_to_scan, output_file_name, write_json_file, core, True,
                               print_matched_text, formats, time_out, correct_mode, correct_filepath,
                               selected_scanner, path_to_exclude, hide_progress=hide_progress,
-                              kb_url=kb_url, kb_token=kb_token)
+                              kb_url=kb_url, kb_token=kb_token,
+                              merge_by_folder=merge_by_folder)
 
         _result_log["Scan Result"] = result[1]
 
@@ -148,7 +153,7 @@ def create_report_file(
     output_extensions: list = [], correct_mode: bool = True,
     correct_filepath: str = "", path_to_scan: str = "", path_to_exclude: list = [],
     formats: list = [], api_limit_exceed: bool = False, files_count: int = 0, final_output_path: str = "",
-    run_kb_msg: str = ""
+    run_kb_msg: str = "", merge_by_folder: bool = False, kb_reference_result: list = None
 ) -> 'ScannerItem':
     """
     Create report files for given scanned result.
@@ -239,12 +244,12 @@ def create_report_file(
             elif selected_scanner == 'scanoss':
                 sheet_list["scanoss_reference"] = get_scanoss_extra_info(scanoss_result)
             elif selected_scanner == 'kb':
-                kb_ref = get_kb_reference_to_print(merged_result)
+                kb_ref = get_kb_reference_to_print(kb_reference_result or merged_result)
                 sheet_list["kb_reference"] = kb_ref
             else:
                 sheet_list["scancode_reference"] = get_license_list_to_print(license_list)
                 sheet_list["scanoss_reference"] = get_scanoss_extra_info(scanoss_result)
-                kb_ref = get_kb_reference_to_print(merged_result)
+                kb_ref = get_kb_reference_to_print(kb_reference_result or merged_result)
                 sheet_list["kb_reference"] = kb_ref
 
         if sheet_list:
@@ -257,6 +262,9 @@ def create_report_file(
         else:
             scan_item = correct_item
             logger.info("Success to correct with yaml.")
+
+    if merged_result and merge_by_folder:
+        scan_item.file_items[PKG_NAME] = merge_results_by_folder(scan_item.file_items[PKG_NAME])
 
     combined_paths_and_files = [os.path.join(output_path, file) for file in output_files]
     results = []
@@ -485,6 +493,107 @@ def _finalize_temp_output(
     return publish_ok
 
 
+def _normalize_merge_text(value: str) -> str:
+    return value.strip() if value else ""
+
+
+def _get_merge_licenses(scan_item: SourceItem) -> tuple:
+    return tuple(sorted([license.strip() for license in scan_item.licenses if license and license.strip()]))
+
+
+def _get_merge_field_value(scan_items: list, value_getter) -> str:
+    for scan_item in scan_items:
+        value = value_getter(scan_item)
+        if value:
+            return value
+    return ""
+
+
+def _is_merge_field_compatible(scan_items: list, value_getter) -> bool:
+    values = []
+    for scan_item in scan_items:
+        value = value_getter(scan_item)
+        if value:
+            values.append(value)
+    return len(set(values)) <= 1
+
+
+def _iter_merge_values(values) -> list:
+    if not values:
+        return []
+    if isinstance(values, str):
+        return [values]
+    return values
+
+
+def _get_top_merge_values(scan_items: list, value_getter) -> list:
+    values = []
+    for scan_item in scan_items:
+        for value in _iter_merge_values(value_getter(scan_item)):
+            normalized_value = _normalize_merge_text(value)
+            if normalized_value:
+                values.append(normalized_value)
+    return [value for value, _ in Counter(values).most_common(3)]
+
+
+def _can_merge_folder(scan_items: list) -> bool:
+    return (
+        len(scan_items) > 1
+        and len({bool(item.exclude) for item in scan_items}) <= 1
+        and _is_merge_field_compatible(scan_items, lambda item: _normalize_merge_text(item.oss_name))
+        and _is_merge_field_compatible(scan_items, lambda item: _normalize_merge_text(item.oss_version))
+        and _is_merge_field_compatible(scan_items, _get_merge_licenses)
+    )
+
+
+def _create_merged_item(scan_items: list, merge_path: str) -> SourceItem:
+    # Reuse the shortest path item as the representative row, but keep original paths untouched.
+    representative_item = min(scan_items, key=lambda item: (len(item.source_name_or_path), item.source_name_or_path))
+    merged_item = copy.copy(representative_item)
+    merged_item.source_name_or_path = f"{merge_path} ({len(scan_items)})"
+    merged_item.oss_name = _get_merge_field_value(scan_items, lambda item: _normalize_merge_text(item.oss_name))
+    merged_item.oss_version = _get_merge_field_value(scan_items, lambda item: _normalize_merge_text(item.oss_version))
+    merged_item._licenses = []
+    merged_item.licenses = list(_get_merge_field_value(scan_items, _get_merge_licenses))
+    merged_downloads = _get_top_merge_values(scan_items, lambda item: item.download_location)
+    merged_copyrights = _get_top_merge_values(scan_items, lambda item: item.copyright)
+    merged_item.download_location = [", ".join(merged_downloads)] if merged_downloads else []
+    merged_item.copyright = [", ".join(merged_copyrights)] if merged_copyrights else []
+    merged_item.set_oss_item(run_kb=False)
+    return merged_item
+
+
+def merge_results_by_folder(scan_result: list) -> list:
+    """
+    Merge output rows within the same folder when OSS name, OSS version, and license are compatible.
+    """
+    # Build a folder tree first so merge never jumps straight to root ".".
+    merge_tree = {"items": [], "children": {}}
+
+    for scan_item in scan_result:
+        normalized_path = os.path.normpath(scan_item.source_name_or_path).replace("\\", "/")
+        path_parts = [part for part in normalized_path.split("/") if part and part != "."]
+        current_node = merge_tree
+
+        for folder_name in path_parts[:-1]:
+            current_node = current_node["children"].setdefault(folder_name, {"items": [], "children": {}})
+        current_node["items"].append(scan_item)
+
+    def merge_node(merge_node_item: dict, merge_path: str = "", depth: int = 0) -> list:
+        # Keep at least one path depth in the report; root-level ". (N)" is too broad.
+        if depth > 0 and _can_merge_folder(merge_node_item["items"]):
+            merged_items = [_create_merged_item(merge_node_item["items"], merge_path)]
+        else:
+            merged_items = list(merge_node_item["items"])
+
+        for folder_name, child_node in merge_node_item["children"].items():
+            child_path = f"{merge_path}/{folder_name}" if merge_path else folder_name
+            merged_items.extend(merge_node(child_node, child_path, depth + 1))
+        return merged_items
+
+    return merge_node(merge_tree)
+
+
 def run_scanners(
     path_to_scan: str, output_file_name: str = "",
     write_json_file: bool = False, num_cores: int = -1,
@@ -492,7 +601,8 @@ def run_scanners(
     formats: list = [], time_out: int = 120,
     correct_mode: bool = True, correct_filepath: str = "",
     selected_scanner: str = ALL_MODE, path_to_exclude: list = [],
-    all_exclude_mode: tuple = (), hide_progress: bool = False, kb_url: str = "", kb_token: str = ""
+    all_exclude_mode: tuple = (), hide_progress: bool = False,
+    kb_url: str = "", kb_token: str = "", merge_by_folder: bool = True
 ) -> Tuple[bool, str, 'ScannerItem', list, list]:
     """
     Run Scancode and scanoss.py for the given path.
@@ -598,7 +708,8 @@ def run_scanners(
                 scan_item = create_report_file(start_time, merged_result, license_list, scanoss_result, selected_scanner,
                                                print_matched_text, output_path, output_files, output_extensions, correct_mode,
                                                correct_filepath, path_to_scan, excluded_path_without_dot, formats,
-                                               api_limit_exceed, cnt_file_except_skipped, final_output_path, run_kb_msg)
+                                               api_limit_exceed, cnt_file_except_skipped, final_output_path, run_kb_msg,
+                                               merge_by_folder, merged_result)
             else:
                 print_help_msg_source_scanner()
                 result_log[RESULT_KEY] = "Unsupported scanner"

--- a/src/fosslight_source/cli.py
+++ b/src/fosslight_source/cli.py
@@ -12,10 +12,6 @@ import logging
 import re
 import urllib.request
 import urllib.error
-import tempfile
-import zipfile
-import defusedxml.ElementTree as ET
-import xml.etree.ElementTree as xmlET
 from datetime import datetime
 import fosslight_util.constant as constant
 from fosslight_util.set_log import init_log
@@ -31,8 +27,6 @@ from .run_scanoss import get_scanoss_extra_info
 import yaml
 import tqdm
 import argparse
-import copy
-from collections import Counter
 from .run_spdx_extractor import get_spdx_downloads
 from .run_manifest_extractor import get_manifest_licenses
 from ._scan_item import SourceItem, resolve_kb_config, is_notice_file
@@ -41,16 +35,19 @@ from fosslight_util.oss_item import ScannerItem
 from typing import Optional, Tuple
 from ._scan_item import is_manifest_file
 import shutil
+from ._merge import (
+    PRE_MERGE_SHEET_NAME,
+    MERGED_HEADER,
+    _add_pre_merge_sheet,
+    _hide_xlsx_sheet,
+    merge_results_by_folder
+)
 
 
 SRC_SHEET_NAME = 'SRC_FL_Source'
-PRE_MERGE_SHEET_NAME = '.SRC_FL_Source_no_merge'
 SCANOSS_HEADER = {SRC_SHEET_NAME: ['ID', 'Source Path', 'OSS Name',
                                    'OSS Version', 'License', 'Download Location',
                                    'Homepage', 'Copyright Text', 'Exclude', 'Comment']}
-MERGED_HEADER = {SRC_SHEET_NAME: ['ID', 'Source Path', 'OSS Name',
-                                  'OSS Version', 'License', 'Download Location',
-                                  'Homepage', 'Copyright Text', 'Exclude', 'Comment', 'license_reference']}
 KB_REFERENCE_HEADER = ['ID', 'Source Path', 'KB Origin URL', 'Evidence']
 ALL_MODE = 'all'
 SCANNER_TYPE = ['kb', 'scancode', 'scanoss', ALL_MODE]
@@ -61,72 +58,6 @@ logger = logging.getLogger(constant.LOGGER_NAME)
 warnings.filterwarnings("ignore", category=FutureWarning)
 PKG_NAME = "fosslight_source"
 RESULT_KEY = "Scan Result"
-
-
-def _get_source_rows_to_print(source_items: list) -> list:
-    source_rows = []
-    for source_item in source_items:
-        source_rows.extend(source_item.get_print_array())
-    return source_rows
-
-
-def _add_pre_merge_sheet(scan_item: 'ScannerItem') -> None:
-    external_sheets = getattr(scan_item, "external_sheets", {}) or {}
-    external_sheets[PRE_MERGE_SHEET_NAME] = [
-        MERGED_HEADER[SRC_SHEET_NAME],
-        *_get_source_rows_to_print(scan_item.file_items.get(PKG_NAME, [])),
-    ]
-    scan_item.external_sheets = external_sheets
-
-
-def _hide_xlsx_sheet(xlsx_path: str, sheet_name: str) -> None:
-    workbook_xml_path = "xl/workbook.xml"
-    namespace_uri = "http://schemas.openxmlformats.org/spreadsheetml/2006/main"
-    relationship_uri = "http://schemas.openxmlformats.org/officeDocument/2006/relationships"
-    xmlET.register_namespace("", namespace_uri)
-    xmlET.register_namespace("r", relationship_uri)
-
-    try:
-        with zipfile.ZipFile(xlsx_path, "r") as workbook:
-            try:
-                workbook_xml = workbook.read(workbook_xml_path)
-            except KeyError:
-                logger.debug(f"Failed to hide sheet. workbook.xml not found: {xlsx_path}")
-                return
-
-            root = ET.fromstring(workbook_xml)
-            target_sheet = None
-            for sheet in root.findall(f".//{{{namespace_uri}}}sheet"):
-                if sheet.attrib.get("name") == sheet_name:
-                    target_sheet = sheet
-                    break
-
-            if target_sheet is None:
-                logger.debug(f"Failed to hide sheet. sheet not found: {sheet_name}")
-                return
-
-            target_sheet.set("state", "hidden")
-            updated_workbook_xml = ET.tostring(root, encoding="utf-8", xml_declaration=True)
-
-            output_dir = os.path.dirname(xlsx_path) or "."
-            with tempfile.NamedTemporaryFile(delete=False, dir=output_dir, suffix=".xlsx") as temp_file:
-                temp_xlsx_path = temp_file.name
-
-            try:
-                with zipfile.ZipFile(temp_xlsx_path, "w") as updated_workbook:
-                    for item in workbook.infolist():
-                        if item.filename == workbook_xml_path:
-                            content = updated_workbook_xml
-                        else:
-                            content = workbook.read(item.filename)
-                        updated_workbook.writestr(item, content)
-                shutil.move(temp_xlsx_path, xlsx_path)
-            except Exception:
-                if os.path.exists(temp_xlsx_path):
-                    os.remove(temp_xlsx_path)
-                raise
-    except Exception as ex:
-        logger.debug(f"Failed to hide sheet {sheet_name}: {ex}")
 
 
 def main() -> None:
@@ -224,7 +155,7 @@ def create_report_file(
     output_extensions: list = [], correct_mode: bool = True,
     correct_filepath: str = "", path_to_scan: str = "", path_to_exclude: list = [],
     formats: list = [], api_limit_exceed: bool = False, files_count: int = 0, final_output_path: str = "",
-    run_kb_msg: str = "", merge_by_folder: bool = False, kb_reference_result: Optional[list] = None
+    run_kb_msg: str = "", merge_by_folder: bool = False
 ) -> 'ScannerItem':
     """
     Create report files for given scanned result.
@@ -315,12 +246,12 @@ def create_report_file(
             elif selected_scanner == 'scanoss':
                 sheet_list["scanoss_reference"] = get_scanoss_extra_info(scanoss_result)
             elif selected_scanner == 'kb':
-                kb_ref = get_kb_reference_to_print(kb_reference_result or merged_result)
+                kb_ref = get_kb_reference_to_print(merged_result)
                 sheet_list["kb_reference"] = kb_ref
             else:
                 sheet_list["scancode_reference"] = get_license_list_to_print(license_list)
                 sheet_list["scanoss_reference"] = get_scanoss_extra_info(scanoss_result)
-                kb_ref = get_kb_reference_to_print(kb_reference_result or merged_result)
+                kb_ref = get_kb_reference_to_print(merged_result)
                 sheet_list["kb_reference"] = kb_ref
 
         if sheet_list:
@@ -572,119 +503,6 @@ def _finalize_temp_output(
     return publish_ok
 
 
-def _normalize_merge_text(value: str) -> str:
-    return value.strip() if value else ""
-
-
-def _get_merge_licenses(scan_item: SourceItem) -> tuple:
-    return tuple(sorted([lic.strip() for lic in scan_item.licenses if lic and lic.strip()]))
-
-
-def _get_merge_download_locations(scan_item: SourceItem) -> tuple:
-    downloads = scan_item.download_location
-    if not downloads:
-        return ()
-    if isinstance(downloads, str):
-        downloads = [downloads]
-    return tuple(sorted([dl.strip() for dl in downloads if dl and dl.strip()]))
-
-
-def _get_merge_field_value(scan_items: list, value_getter) -> str:
-    for scan_item in scan_items:
-        value = value_getter(scan_item)
-        if value:
-            return value
-    return ""
-
-
-def _is_merge_field_compatible(scan_items: list, value_getter) -> bool:
-    values = []
-    for scan_item in scan_items:
-        value = value_getter(scan_item)
-        if value:
-            values.append(value)
-    return len(set(values)) <= 1
-
-
-def _iter_merge_values(values) -> list:
-    if not values:
-        return []
-    if isinstance(values, str):
-        return [values]
-    return values
-
-
-def _get_top_merge_values(scan_items: list, value_getter) -> list:
-    values = []
-    for scan_item in scan_items:
-        for value in _iter_merge_values(value_getter(scan_item)):
-            normalized_value = _normalize_merge_text(value)
-            if normalized_value:
-                values.append(normalized_value)
-    return [value for value, _ in Counter(values).most_common(3)]
-
-
-def _can_merge_folder(scan_items: list) -> bool:
-    return (
-        len(scan_items) > 1
-        and _is_merge_field_compatible(scan_items, lambda item: _normalize_merge_text(item.oss_name))
-        and _is_merge_field_compatible(scan_items, lambda item: _normalize_merge_text(item.oss_version))
-        and _is_merge_field_compatible(scan_items, _get_merge_licenses)
-        and _is_merge_field_compatible(scan_items, _get_merge_download_locations)
-    )
-
-
-def _create_merged_item(scan_items: list, merge_path: str) -> SourceItem:
-    # Reuse the shortest path item as the representative row, but keep original paths untouched.
-    representative_item = min(scan_items, key=lambda item: (len(item.source_name_or_path), item.source_name_or_path))
-    merged_item = copy.copy(representative_item)
-    merged_item.source_name_or_path = f"{merge_path} ({len(scan_items)})"
-    merged_item.oss_name = _get_merge_field_value(scan_items, lambda item: _normalize_merge_text(item.oss_name))
-    merged_item.oss_version = _get_merge_field_value(scan_items, lambda item: _normalize_merge_text(item.oss_version))
-    merged_item._licenses = []
-    merged_item.licenses = list(_get_merge_field_value(scan_items, _get_merge_licenses))
-    merged_downloads = _get_merge_field_value(scan_items, _get_merge_download_locations)
-    merged_item.download_location = list(merged_downloads) if merged_downloads else []
-    merged_copyrights = _get_top_merge_values(scan_items, lambda item: item.copyright)
-    merged_item.copyright = merged_copyrights if merged_copyrights else []
-    merged_item.set_oss_item(run_kb=False)
-    return merged_item
-
-
-def merge_results_by_folder(scan_result: list) -> list:
-    """
-    Merge output rows within the same folder when OSS name, OSS version, and license are compatible.
-    """
-    # Build a folder tree first so merge never jumps straight to root ".".
-    merge_tree = {"items": [], "children": {}}
-
-    for scan_item in scan_result:
-        normalized_path = os.path.normpath(scan_item.source_name_or_path).replace("\\", "/")
-        path_parts = [part for part in normalized_path.split("/") if part and part != "."]
-        current_node = merge_tree
-
-        for folder_name in path_parts[:-1]:
-            current_node = current_node["children"].setdefault(folder_name, {"items": [], "children": {}})
-        current_node["items"].append(scan_item)
-
-    def merge_node(merge_node_item: dict, merge_path: str = "", depth: int = 0) -> list:
-        excluded_items = [item for item in merge_node_item["items"] if item.exclude]
-        eligible_items = [item for item in merge_node_item["items"] if not item.exclude]
-
-        # Keep at least one path depth in the report; root-level ". (N)" is too broad.
-        if depth > 0 and _can_merge_folder(eligible_items):
-            merged_items = [_create_merged_item(eligible_items, merge_path)] + excluded_items
-        else:
-            merged_items = list(merge_node_item["items"])
-
-        for folder_name, child_node in merge_node_item["children"].items():
-            child_path = f"{merge_path}/{folder_name}" if merge_path else folder_name
-            merged_items.extend(merge_node(child_node, child_path, depth + 1))
-        return merged_items
-
-    return merge_node(merge_tree)
-
-
 def run_scanners(
     path_to_scan: str, output_file_name: str = "",
     write_json_file: bool = False, num_cores: int = -1,
@@ -800,7 +618,7 @@ def run_scanners(
                                                print_matched_text, output_path, output_files, output_extensions, correct_mode,
                                                correct_filepath, path_to_scan, excluded_path_without_dot, formats,
                                                api_limit_exceed, cnt_file_except_skipped, final_output_path, run_kb_msg,
-                                               merge_by_folder, merged_result)
+                                               merge_by_folder)
             else:
                 print_help_msg_source_scanner()
                 result_log[RESULT_KEY] = "Unsupported scanner"

--- a/src/fosslight_source/cli.py
+++ b/src/fosslight_source/cli.py
@@ -130,14 +130,11 @@ def main() -> None:
     core = args.cores
 
     if os.path.isdir(path_to_scan):
-        result = []
-        _total_start = time.time()
         result = run_scanners(path_to_scan, output_file_name, write_json_file, core, True,
                               print_matched_text, formats, time_out, correct_mode, correct_filepath,
                               selected_scanner, path_to_exclude, hide_progress=hide_progress,
                               kb_url=kb_url, kb_token=kb_token,
                               merge_by_folder=merge_by_folder)
-        logger.info(f"[TIMING] run_scanners total: {time.time() - _total_start:.4f}s")
 
         _result_log["Scan Result"] = result[1]
 
@@ -272,7 +269,7 @@ def create_report_file(
         _add_pre_merge_sheet(scan_item, PRE_MERGE_SHEET_NAME, MERGED_HEADER[SRC_SHEET_NAME], PKG_NAME)
         _merge_start = time.time()
         scan_item.file_items[PKG_NAME] = merge_results_by_folder(scan_item.file_items[PKG_NAME])
-        logger.info(f"[TIMING] merge_results_by_folder: {time.time() - _merge_start:.4f}s")
+        logger.debug(f"[TIMING] merge_results_by_folder: {time.time() - _merge_start:.4f}s")
 
     combined_paths_and_files = [os.path.join(output_path, file) for file in output_files]
     results = []

--- a/src/fosslight_source/cli.py
+++ b/src/fosslight_source/cli.py
@@ -160,7 +160,6 @@ def create_report_file(
     :param license_list: matched text (only for scancode).
     :param need_license: if requested, output matched text (only for scancode).
     """
-    extended_header = {}
     sheet_list = {}
     _json_ext = ".json"
 
@@ -267,7 +266,7 @@ def create_report_file(
         # if need_license and output_extension == _json_ext and "scanoss_reference" in sheet_list:
         #     del sheet_list["scanoss_reference"]
         result = write_output_file(
-            combined_path_and_file, output_extension, scan_item, extended_header, "", output_format
+            combined_path_and_file, output_extension, scan_item, hide_header="", format=output_format
         )
         results.append(result)
     for success, msg, result_file in results:


### PR DESCRIPTION
* **New Features**
  * Add folder-level summary rows for source reports by merging compatible file-based scan results within the same folder.
  * Add `--no_merge` option to keep source report output file-based when folder summary is not needed.
  * Add a hidden `.SRC_FL_Source_before_merge` sheet in XLSX reports to preserve the original pre-merge source rows.