### PR TITLE
Fix release CI failures from cryptography and pytest-flake8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,8 @@ dependencies = [
     "intbitset",
     "fosslight_binary>=5.1.22",
     "scancode-toolkit>=32.0.2",
+    # cryptography 49.x does not provide macOS x86_64 wheels, causing source builds to require OpenSSL/pkg-config.
+    "cryptography<49; platform_system == 'Darwin' and platform_machine == 'x86_64'",
     "fingerprints==1.2.3",
     "normality==2.6.1",
     # Python 3.13+ needs psycopg2-binary 2.9.10+ (has wheels; 2.9.9 builds fail with _PyInterpreterState_Get)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,6 @@
 tox
 pytest
 pytest-cov
-pytest-flake8
 flake8
 dataclasses
 scanoss

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,7 @@ allowlist_externals =
   rm
   ls
   pytest
+  flake8
 setenv =
   PYTHONPATH=.
 
@@ -38,8 +39,9 @@ commands =
             --maxfail=1 --disable-warnings
 
   python tests/cli_test.py
-  pytest -v --flake8
+  flake8 -j 4
 
 [testenv:flake8]
-deps = pytest-flake8
-commands = pytest -v --flake8
+deps =
+  -r{toxinidir}/requirements-dev.txt
+commands = flake8 -j 4


### PR DESCRIPTION
## Description
* Added a macOS x86_64-specific `cryptography<49` dependency constraint.
  * Prevents `pip install .` from resolving to `cryptography 49.x`, which does not provide macOS x86_64 wheels and falls back to a source build requiring OpenSSL/pkg-config.
  * Keeps the constraint limited to Intel macOS so Linux, Windows, and macOS arm64 can continue using newer compatible `cryptography` releases.
* Run flake8 directly instead of pytest-flake8