### PR TITLE
Fix refine regex pattern for parsing custom license

### DIFF
--- a/src/fosslight_source/_parsing_scancode_file_item.py
+++ b/src/fosslight_source/_parsing_scancode_file_item.py
@@ -15,7 +15,7 @@ from typing import Tuple
 
 logger = logging.getLogger(constant.LOGGER_NAME)
 REMOVE_LICENSE = ["warranty-disclaimer"]
-regex = re.compile(r'licenseref-(\S+)', re.IGNORECASE)
+regex = re.compile(r'licenseref-([a-z0-9\.\-]+)', re.IGNORECASE)
 find_word = re.compile(rb"SPDX-PackageDownloadLocation\s*:\s*(\S+)", re.IGNORECASE)
 KEYWORD_SPDX_ID = r'SPDX-License-Identifier\s*[\S]+'
 KEYWORD_DOWNLOAD_LOC = r'DownloadLocation\s*[\S]+'


### PR DESCRIPTION
## Description
Refine the regex pattern for custom license parsing to exclude trailing punctuation and formatting characters.

* **Problem**: The previous regex (`licenseref-(\S+)`) captured trailing punctuation or markup.
* **Solution**: Updated the regex to `licenseref-([a-z0-9\.\-]+)` to match only valid SPDX identifier characters.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of source code analysis by refining how license information is extracted during file scanning. This enhancement ensures more precise license detection results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->