### PR TITLE
Print kb server message on Cover sheet

### DIFF
--- a/src/fosslight_source/_kb_client.py
+++ b/src/fosslight_source/_kb_client.py
@@ -8,7 +8,7 @@ import logging
 import time
 import urllib.error
 import urllib.request
-from typing import Dict, List
+from typing import Dict, List, NamedTuple, Optional
 
 import fosslight_util.constant as constant
 
@@ -59,39 +59,106 @@ def _coerce_count(value, default: int) -> int:
     return count if count >= 0 else default
 
 
+def _extract_response_message(response_body: dict) -> Optional[str]:
+    message = response_body.get("message")
+    if isinstance(message, str):
+        message = message.strip()
+        if message:
+            return message
+    return None
+
+
+def _scan_job_failure_message(response_body: dict) -> Optional[str]:
+    """Return server message when a scan/jobs response indicates failure."""
+    message = _extract_response_message(response_body)
+    if not message:
+        return None
+
+    status = response_body.get("status")
+    if status is None or str(status).lower() == "failed":
+        return message
+
+    if not response_body.get("job_id"):
+        return message
+
+    return None
+
+
+def _parse_http_error_body(error: urllib.error.HTTPError) -> dict:
+    try:
+        raw = error.read().decode()
+        return json.loads(raw) if raw else {}
+    except (json.JSONDecodeError, UnicodeDecodeError, OSError):
+        return {}
+
+
+class KbScanJobResult(NamedTuple):
+    origin_urls: Dict[str, str]
+    failure_message: Optional[str]
+    requested_count: int
+    returned_count: int
+
+
+def _kb_scan_job_result(
+    origin_urls: Dict[str, str],
+    failure_message: Optional[str],
+    requested_count: int,
+) -> KbScanJobResult:
+    return KbScanJobResult(
+        origin_urls=origin_urls,
+        failure_message=failure_message,
+        requested_count=requested_count,
+        returned_count=len(origin_urls),
+    )
+
+
 def fetch_origin_urls_via_scan_job(
     file_hashes: List[str],
     kb_url: str,
     kb_token: str,
-) -> Dict[str, str]:
+) -> KbScanJobResult:
     """
     Create a POST /scan/jobs request, poll until completion, and return a file_hash -> origin_url map.
     :param file_hashes: list of MD5 file hashes to look up.
     :param kb_url: KB API base URL.
     :param kb_token: KB API bearer token.
-    :return: mapping of file_hash to origin_url for successful matches.
+    :return: origin URLs, optional failure message, and requested/returned file_hash counts.
     """
     unique_hashes = list(dict.fromkeys(h for h in file_hashes if h))
+    requested_count = len(unique_hashes)
     if not unique_hashes:
-        return {}
+        return _kb_scan_job_result({}, None, 0)
 
     create_payload = {"file_hashes": unique_hashes}
     try:
         created = _kb_request(kb_url, "scan/jobs", method="POST", payload=create_payload, kb_token=kb_token)
     except urllib.error.HTTPError as e:
+        failure_message = _scan_job_failure_message(_parse_http_error_body(e))
+        if failure_message:
+            logger.warning(f"KB scan job create failed: {failure_message}")
+            return _kb_scan_job_result({}, failure_message, requested_count)
         logger.warning(f"KB scan job create failed: HTTP {e.code} {e.reason}")
-        return {}
+        return _kb_scan_job_result({}, None, requested_count)
     except urllib.error.URLError as e:
         logger.warning(f"KB scan job create failed: {e}")
-        return {}
+        return _kb_scan_job_result({}, None, requested_count)
     except Exception as e:
         logger.warning(f"KB scan job create failed: {e}")
-        return {}
+        return _kb_scan_job_result({}, None, requested_count)
+
+    failure_message = _scan_job_failure_message(created)
+    if failure_message:
+        logger.warning(f"KB scan job create failed: {failure_message}")
+        return _kb_scan_job_result({}, failure_message, requested_count)
+
+    if str(created.get("status", "")).lower() == "failed":
+        logger.warning("KB scan job create failed")
+        return _kb_scan_job_result({}, None, requested_count)
 
     job_id = created.get("job_id", "")
     if not job_id:
         logger.warning("KB scan job create response missing job_id")
-        return {}
+        return _kb_scan_job_result({}, None, requested_count)
 
     fallback_count = len(unique_hashes)
     accepted = _coerce_count(
@@ -106,7 +173,12 @@ def fetch_origin_urls_via_scan_job(
     if skipped:
         logger.warning(f"KB scan job rate-limited: {skipped} file_hash(es) skipped by server")
     if accepted == 0:
-        return {}
+        failure_message = (
+            f"rate-limited: {skipped} file_hash(es) skipped by server"
+            if skipped
+            else "scan job accepted no file_hashes"
+        )
+        return _kb_scan_job_result({}, failure_message, requested_count)
 
     deadline = time.monotonic() + _estimate_job_wait_timeout(accepted)
     interval = _SCAN_JOB_POLL_INTERVAL_SEC
@@ -118,7 +190,11 @@ def fetch_origin_urls_via_scan_job(
         except urllib.error.HTTPError as e:
             if e.code == 404:
                 logger.warning(f"KB scan job not found: {job_id}")
-                return {}
+                return _kb_scan_job_result(origin_urls, "scan job not found", requested_count)
+            failure_message = _scan_job_failure_message(_parse_http_error_body(e))
+            if failure_message:
+                logger.warning(f"KB scan job status failed: {failure_message}")
+                return _kb_scan_job_result(origin_urls, failure_message, requested_count)
             logger.warning(f"KB scan job status failed: HTTP {e.code}")
             time.sleep(interval)
             interval = min(interval * 1.5, _SCAN_JOB_POLL_MAX_INTERVAL_SEC)
@@ -146,14 +222,18 @@ def fetch_origin_urls_via_scan_job(
                 f"KB scan job completed: job_id={job_id}, "
                 f"matched={len(origin_urls)}, failed={status.get('failed', 0)}"
             )
-            return origin_urls
+            return _kb_scan_job_result(origin_urls, None, requested_count)
 
         if job_status == "failed":
-            logger.warning(f"KB scan job failed: job_id={job_id}")
-            return {}
+            failure_message = _scan_job_failure_message(status)
+            if failure_message:
+                logger.warning(f"KB scan job failed: job_id={job_id}, message={failure_message}")
+            else:
+                logger.warning(f"KB scan job failed: job_id={job_id}")
+            return _kb_scan_job_result(origin_urls, failure_message or "scan job failed", requested_count)
 
         time.sleep(interval)
         interval = min(interval * 1.5, _SCAN_JOB_POLL_MAX_INTERVAL_SEC)
 
     logger.warning(f"KB scan job timed out: job_id={job_id}")
-    return origin_urls
+    return _kb_scan_job_result(origin_urls, "scan job timed out", requested_count)

--- a/src/fosslight_source/cli.py
+++ b/src/fosslight_source/cli.py
@@ -29,7 +29,7 @@ import tqdm
 import argparse
 from .run_spdx_extractor import get_spdx_downloads
 from .run_manifest_extractor import get_manifest_licenses
-from ._scan_item import SourceItem, resolve_kb_config
+from ._scan_item import SourceItem, resolve_kb_config, is_notice_file
 from ._kb_client import fetch_origin_urls_via_scan_job
 from fosslight_util.oss_item import ScannerItem
 from typing import Optional, Tuple
@@ -343,7 +343,7 @@ def _collect_kb_file_hashes(
     extra_candidates: list[tuple[SourceItem, str]] = []
 
     for item in scancode_result:
-        if item.is_license_text:
+        if item.is_license_text or is_notice_file(item.source_name_or_path):
             continue
         md5_hash, _wfp = item._get_hash(path_to_scan)
         if md5_hash:
@@ -360,7 +360,7 @@ def _collect_kb_file_hashes(
 
     for file_path in tqdm.tqdm(files_to_scan, desc="KB Hashing", disable=hide_progress):
         rel_path = os.path.relpath(file_path, abs_path_to_scan).replace("\\", "/")
-        if rel_path in scancode_paths or rel_path in excluded_files:
+        if rel_path in scancode_paths or rel_path in excluded_files or is_notice_file(file_path):
             continue
         extra_item = SourceItem(rel_path)
         md5_hash, _wfp = extra_item._get_hash(path_to_scan)

--- a/src/fosslight_source/cli.py
+++ b/src/fosslight_source/cli.py
@@ -32,7 +32,7 @@ from .run_manifest_extractor import get_manifest_licenses
 from ._scan_item import SourceItem, resolve_kb_config
 from ._kb_client import fetch_origin_urls_via_scan_job
 from fosslight_util.oss_item import ScannerItem
-from typing import Tuple
+from typing import Optional, Tuple
 from ._scan_item import is_manifest_file
 import shutil
 
@@ -376,7 +376,7 @@ def merge_results(
     scancode_result: list = [], scanoss_result: list = [], spdx_downloads: dict = {},
     path_to_scan: str = "", run_kb: bool = False, manifest_licenses: dict = {},
     excluded_files: set = None, hide_progress: bool = False, kb_url: str = "", kb_token: str = ""
-) -> list:
+) -> tuple[list, Optional[str], int, int]:
 
     """
     Merge scanner results and spdx parsing result.
@@ -388,7 +388,7 @@ def merge_results(
     :param excluded_files: set of relative paths to exclude from KB-only file discovery.
     :param kb_url: KB API base URL.
     :param kb_token: KB API bearer token.
-    :return merged_result: list of merged result in SourceItem.
+    :return: (merged_result, kb failure message, requested file_hash count, returned match count).
     """
     if excluded_files is None:
         excluded_files = set()
@@ -424,13 +424,20 @@ def merge_results(
                 scancode_result.append(new_result_item)
 
     kb_origin_urls: dict[str, str] = {}
+    kb_status_message: Optional[str] = None
+    kb_requested_count = 0
+    kb_returned_count = 0
     extra_candidates: list[tuple[SourceItem, str]] = []
     if run_kb:
         file_hashes, extra_candidates = _collect_kb_file_hashes(
             scancode_result, path_to_scan, excluded_files, hide_progress
         )
         if file_hashes:
-            kb_origin_urls = fetch_origin_urls_via_scan_job(file_hashes, kb_url, kb_token)
+            kb_result = fetch_origin_urls_via_scan_job(file_hashes, kb_url, kb_token)
+            kb_origin_urls = kb_result.origin_urls
+            kb_status_message = kb_result.failure_message
+            kb_requested_count = kb_result.requested_count
+            kb_returned_count = kb_result.returned_count
 
     for item in scancode_result:
         item.set_oss_item(path_to_scan, kb_origin_urls=kb_origin_urls)
@@ -443,7 +450,7 @@ def merge_results(
             if extra_item.download_location:
                 scancode_result.append(extra_item)
 
-    return scancode_result
+    return scancode_result, kb_status_message, kb_requested_count, kb_returned_count
 
 
 def run_scanners(
@@ -537,13 +544,20 @@ def run_scanners(
                 if not check_kb_server_reachable(kb_url, kb_token):
                     run_kb = False
                     run_kb_msg = f"KB({kb_url}) Unreachable"
-                else:
-                    run_kb_msg = f"KB({kb_url}) Enabled"
 
             spdx_downloads, manifest_licenses = metadata_collector(path_to_scan, excluded_files)
-            merged_result = merge_results(scancode_result, scanoss_result, spdx_downloads,
-                                          path_to_scan, run_kb, manifest_licenses, excluded_files,
-                                          hide_progress, kb_url, kb_token)
+            merged_result, kb_status_message, kb_requested_count, kb_returned_count = merge_results(
+                scancode_result, scanoss_result, spdx_downloads,
+                path_to_scan, run_kb, manifest_licenses, excluded_files,
+                hide_progress, kb_url, kb_token,
+            )
+            if kb_status_message:
+                run_kb_msg = f"KB({kb_url}) {kb_status_message}"
+            elif run_kb and kb_requested_count > 0:
+                run_kb_msg = (
+                    f"KB({kb_url}) response : {kb_returned_count}/"
+                    f" requested: {kb_requested_count}"
+                )
             mark_oss_info_correction_files_as_excluded(merged_result)
             scan_item = create_report_file(start_time, merged_result, license_list, scanoss_result, selected_scanner,
                                            print_matched_text, output_path, output_files, output_extensions, correct_mode,


### PR DESCRIPTION
## Description
Parse ldb_service message on scan/jobs failures and stop polling immediately on auth errors. On success, show matched/requested file_hash counts instead of a generic Enabled line.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved KB scan-job handling so users now get clearer status messages when a scan request fails, times out, or returns no results.
  * Fixed result reporting to better reflect how many hashes were requested versus how many origin URLs were returned.
  * Made scan processing more resilient when the KB service returns malformed or missing error details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->