### PR TITLE
Skip ScanCode only-findings when --ui is set

### DIFF
--- a/src/fosslight_source/_parsing_scancode_file_item.py
+++ b/src/fosslight_source/_parsing_scancode_file_item.py
@@ -73,7 +73,9 @@ def get_error_from_header(header_item: list) -> Tuple[bool, str]:
     return has_error, str_error
 
 
-def parsing_scancode_32_earlier(scancode_file_list: list, has_error: bool = False) -> Tuple[bool, list, list, dict]:
+def parsing_scancode_32_earlier(
+    scancode_file_list: list, has_error: bool = False, ui_mode: bool = False
+) -> Tuple[bool, list, list, dict]:
     rc = True
     msg = []
     scancode_file_item = []
@@ -119,7 +121,9 @@ def parsing_scancode_32_earlier(scancode_file_list: list, has_error: bool = Fals
                     # Set the license value
                     license_detected = []
                     if licenses is None or licenses == "":
-                        continue
+                        if not ui_mode:
+                            continue
+                        licenses = []
 
                     license_expression_list = file.get("license_expressions", {})
                     if len(license_expression_list) > 0:
@@ -192,6 +196,9 @@ def parsing_scancode_32_earlier(scancode_file_list: list, has_error: bool = Fals
                             result_item.comment = ','.join(license_expression_list)
 
                         scancode_file_item.append(result_item)
+                    elif ui_mode:
+                        result_item.copyright = copyright_value_list
+                        scancode_file_item.append(result_item)
             except Exception as ex:
                 msg.append(f"Error Parsing item: {ex}")
                 rc = False
@@ -223,7 +230,7 @@ def get_license_expression_spdx(license_expression: str) -> str:
 
 
 def parsing_scancode_32_later(
-    scancode_file_list: list, has_error: bool = False
+    scancode_file_list: list, has_error: bool = False, ui_mode: bool = False
 ) -> Tuple[bool, list, list, dict]:
     rc = True
     msg = []
@@ -258,9 +265,9 @@ def parsing_scancode_32_later(
                         copyright_value_list.append(copyright_data)
                 license_detected = []
                 licenses = file.get("license_detections", [])
-                if not licenses:
+                if not licenses and not ui_mode:
                     continue
-                for lic in licenses:
+                for lic in licenses or []:
                     matched_lic_list = lic.get("matches", [])
                     for matched_lic in matched_lic_list:
                         found_lic_list = matched_lic.get("license_expression", "")
@@ -322,7 +329,8 @@ def parsing_scancode_32_later(
 
 
 def parsing_file_item(
-    scancode_file_list: list, has_error: bool, need_matched_license: bool = False
+    scancode_file_list: list, has_error: bool, need_matched_license: bool = False,
+    ui_mode: bool = False
 ) -> Tuple[bool, list, list, dict]:
 
     rc = True
@@ -330,9 +338,13 @@ def parsing_file_item(
 
     first_item = next(iter(scancode_file_list or []), {})
     if "licenses" in first_item:
-        rc, scancode_file_item, msg, license_list = parsing_scancode_32_earlier(scancode_file_list, has_error)
+        rc, scancode_file_item, msg, license_list = parsing_scancode_32_earlier(
+            scancode_file_list, has_error, ui_mode
+        )
     else:
-        rc, scancode_file_item, msg, license_list = parsing_scancode_32_later(scancode_file_list, has_error)
+        rc, scancode_file_item, msg, license_list = parsing_scancode_32_later(
+            scancode_file_list, has_error, ui_mode
+        )
     if not need_matched_license:
         license_list = {}
     return rc, scancode_file_item, msg, license_list

--- a/src/fosslight_source/cli.py
+++ b/src/fosslight_source/cli.py
@@ -90,6 +90,7 @@ def main() -> None:
     parser.add_argument('--kb_url', type=str, required=False, default="")
     parser.add_argument('--kb_token', type=str, required=False, default="")
     parser.add_argument('--no_merge', action='store_true', required=False)
+    parser.add_argument('--ui', action='store_true', required=False)
 
     args = parser.parse_args()
 
@@ -121,6 +122,7 @@ def main() -> None:
     kb_url = args.kb_url
     kb_token = args.kb_token
     merge_by_folder = not args.no_merge
+    ui_mode = args.ui
 
     time_out = args.timeout
     core = args.cores
@@ -130,7 +132,7 @@ def main() -> None:
                               print_matched_text, formats, time_out, correct_mode, correct_filepath,
                               selected_scanner, path_to_exclude, hide_progress=hide_progress,
                               kb_url=kb_url, kb_token=kb_token,
-                              merge_by_folder=merge_by_folder)
+                              merge_by_folder=merge_by_folder, ui_mode=ui_mode)
 
         _result_log["Scan Result"] = result[1]
         try:
@@ -521,7 +523,8 @@ def run_scanners(
     correct_mode: bool = True, correct_filepath: str = "",
     selected_scanner: str = ALL_MODE, path_to_exclude: list = [],
     all_exclude_mode: tuple = (), hide_progress: bool = False,
-    kb_url: str = "", kb_token: str = "", merge_by_folder: bool = True
+    kb_url: str = "", kb_token: str = "", merge_by_folder: bool = True,
+    ui_mode: bool = False
 ) -> Tuple[bool, str, 'ScannerItem', list, list]:
     """
     Run Scancode and scanoss.py for the given path.
@@ -601,6 +604,7 @@ def run_scanners(
                     print_matched_text, formats, called_by_cli, time_out, correct_mode,
                     correct_filepath, path_to_exclude,
                     hide_progress=hide_progress,
+                    ui_mode=ui_mode,
                 )
             excluded_files = set(excluded_files) if excluded_files else set()
             if selected_scanner in ['scanoss', ALL_MODE]:

--- a/src/fosslight_source/run_scancode.py
+++ b/src/fosslight_source/run_scancode.py
@@ -398,7 +398,8 @@ def run_scan(
                             msg = "Failed to analyze :" + error_msg
                     if "files" in results:
                         rc, result_list, parsing_msg, license_list = parsing_file_item(results["files"],
-                                                                                       has_error, need_license)
+                                                                                       has_error, need_license,
+                                                                                       ui_mode=ui_mode)
                         if parsing_msg:
                             _result_log["Parsing Log"] = parsing_msg
                         if rc:

--- a/src/fosslight_source/run_scancode.py
+++ b/src/fosslight_source/run_scancode.py
@@ -273,7 +273,8 @@ def run_scan(
     formats: list = [], called_by_cli: bool = False,
     time_out: int = 120, correct_mode: bool = True,
     correct_filepath: str = "", path_to_exclude: list = [],
-    excluded_files: list = [], hide_progress: bool = False
+    excluded_files: list = [], hide_progress: bool = False,
+    ui_mode: bool = False
 ) -> Tuple[bool, str, list, list]:
     if not called_by_cli:
         global logger
@@ -374,7 +375,8 @@ def run_scan(
                     "processes": num_cores,
                     "pretty_params": pretty_params,
                     "output_json_pp": output_json_file,
-                    "only_findings": True,
+                    # UI mode needs all scanned files; omit only_findings for that case.
+                    "only_findings": not ui_mode,
                     "license_text": True,
                     "url": True,
                     "timeout": time_out,


### PR DESCRIPTION
Pass ui_mode through to run_scan so UI mode receives all scanned files instead of findings-only ScanCode output.
