### PR TITLE
Keep copyright findings without full-file ScanCode output

### DIFF
--- a/src/fosslight_source/_parsing_scancode_file_item.py
+++ b/src/fosslight_source/_parsing_scancode_file_item.py
@@ -120,10 +120,11 @@ def parsing_scancode_32_earlier(
 
                     # Set the license value
                     license_detected = []
-                    if licenses is None or licenses == "":
-                        if not ui_mode:
-                            continue
+                    if not licenses:
                         licenses = []
+                    # Keep license and/or copyright findings; UI keeps finding-less files too.
+                    if not licenses and not copyright_value_list and not ui_mode:
+                        continue
 
                     license_expression_list = file.get("license_expressions", {})
                     if len(license_expression_list) > 0:
@@ -196,7 +197,7 @@ def parsing_scancode_32_earlier(
                             result_item.comment = ','.join(license_expression_list)
 
                         scancode_file_item.append(result_item)
-                    elif ui_mode:
+                    elif copyright_value_list or ui_mode:
                         result_item.copyright = copyright_value_list
                         scancode_file_item.append(result_item)
             except Exception as ex:
@@ -265,7 +266,8 @@ def parsing_scancode_32_later(
                         copyright_value_list.append(copyright_data)
                 license_detected = []
                 licenses = file.get("license_detections", [])
-                if not licenses and not ui_mode:
+                # Keep license and/or copyright findings; UI keeps finding-less files too.
+                if not licenses and not copyright_value_list and not ui_mode:
                     continue
                 for lic in licenses or []:
                     matched_lic_list = lic.get("matches", [])

--- a/src/fosslight_source/cli.py
+++ b/src/fosslight_source/cli.py
@@ -392,7 +392,8 @@ def _collect_kb_file_hashes(
 def merge_results(
     scancode_result: list = [], scanoss_result: list = [], spdx_downloads: dict = {},
     path_to_scan: str = "", run_kb: bool = False, manifest_licenses: dict = {},
-    excluded_files: set = None, hide_progress: bool = False, kb_url: str = "", kb_token: str = ""
+    excluded_files: set = None, hide_progress: bool = False, kb_url: str = "", kb_token: str = "",
+    ui_mode: bool = False
 ) -> tuple[list, Optional[str], int, int]:
 
     """
@@ -402,6 +403,9 @@ def merge_results(
     replace the ScanCode license; only OSS name, version, and download location
     from ScanOSS are applied. ScanOSS-only files are appended in full.
 
+    When ui_mode is False, items with both empty download location and empty
+    license are removed after merging.
+
     :param scancode_result: list of scancode results in SourceItem.
     :param scanoss_result: list of scanoss results in SourceItem.
     :param spdx_downloads: dictionary of spdx parsed results.
@@ -410,6 +414,7 @@ def merge_results(
     :param excluded_files: set of relative paths to exclude from KB-only file discovery.
     :param kb_url: KB API base URL.
     :param kb_token: KB API bearer token.
+    :param ui_mode: if False, drop items with no download location and no license.
     :return: (merged_result, kb failure message, requested file_hash count, returned match count).
     """
     if excluded_files is None:
@@ -486,7 +491,26 @@ def merge_results(
             if extra_item.download_location:
                 scancode_result.append(extra_item)
 
+    if not ui_mode:
+        scancode_result[:] = [
+            item for item in scancode_result
+            if not _has_empty_download_and_license(item)
+        ]
+
     return scancode_result, kb_status_message, kb_requested_count, kb_returned_count
+
+
+def _has_empty_download_and_license(item: SourceItem) -> bool:
+    downloads = item.download_location
+    if isinstance(downloads, str):
+        has_download = bool(downloads.strip())
+    else:
+        has_download = bool(downloads) and any(bool(d and str(d).strip()) for d in downloads)
+
+    licenses = item.licenses
+    has_license = bool(licenses) and any(bool(lic and str(lic).strip()) for lic in licenses)
+
+    return (not has_download) and (not has_license)
 
 
 def _finalize_temp_output(
@@ -625,6 +649,7 @@ def run_scanners(
                     scancode_result, scanoss_result, spdx_downloads,
                     path_to_scan, run_kb, manifest_licenses, excluded_files,
                     hide_progress, kb_url, kb_token,
+                    ui_mode=ui_mode,
                 )
                 if kb_status_message:
                     run_kb_msg = f"KB({kb_url}) {kb_status_message}"

--- a/src/fosslight_source/run_scancode.py
+++ b/src/fosslight_source/run_scancode.py
@@ -375,7 +375,7 @@ def run_scan(
                     "processes": num_cores,
                     "pretty_params": pretty_params,
                     "output_json_pp": output_json_file,
-                    # UI mode needs all scanned files; omit only_findings for that case.
+                    # Non-UI: only files with findings (license/copyright). UI: all files.
                     "only_findings": not ui_mode,
                     "license_text": True,
                     "url": True,
@@ -397,9 +397,9 @@ def run_scan(
                             _result_log["Error_files"] = error_msg
                             msg = "Failed to analyze :" + error_msg
                     if "files" in results:
-                        rc, result_list, parsing_msg, license_list = parsing_file_item(results["files"],
-                                                                                       has_error, need_license,
-                                                                                       ui_mode=ui_mode)
+                        rc, result_list, parsing_msg, license_list = parsing_file_item(
+                            results["files"], has_error, need_license, ui_mode=ui_mode
+                        )
                         if parsing_msg:
                             _result_log["Parsing Log"] = parsing_msg
                         if rc:


### PR DESCRIPTION
  * Improved scan results so files containing copyright information are retained even when no license is detected.
  * Refined non-UI result filtering to remove only entries lacking both license information and a download location.
  * Ensured UI mode continues to display relevant items, including entries without licenses or download locations.