### PR TITLE
Support and log timeout for SCANOSS

### DIFF
--- a/src/fosslight_source/_help.py
+++ b/src/fosslight_source/_help.py
@@ -37,7 +37,7 @@ _HELP_MESSAGE_SOURCE_SCANNER = f"""
     ────────────────────────────────────────────────────────────────────
     -s <mode>              Choose mode: scancode, scanoss, kb, or all(default)
     -c <number>            Number of CPU cores/threads to use for scanning
-    -t <seconds>           Timeout in seconds for ScanCode scanning
+    -t <seconds>           Timeout in seconds for ScanCode and SCANOSS scanning
     -j                     Generate raw scanner results in JSON format
     --no_merge             Keep source paths file-based without folder merge
     --no_correction        Skip OSS information correction with sbom-info.yaml

--- a/src/fosslight_source/cli.py
+++ b/src/fosslight_source/cli.py
@@ -639,7 +639,7 @@ def run_scanners(
             if selected_scanner in ['scanoss', ALL_MODE]:
                 scanoss_result, api_limit_exceed = run_scanoss_py(path_to_scan, output_path, formats, True, num_cores,
                                                                   excluded_path_with_default_exclusion, excluded_files,
-                                                                  write_json_file, hide_progress)
+                                                                  write_json_file, hide_progress, timeout=time_out)
 
             run_kb_msg = ""
             if selected_scanner in SCANNER_TYPE:

--- a/src/fosslight_source/cli.py
+++ b/src/fosslight_source/cli.py
@@ -151,7 +151,7 @@ def create_report_file(
     output_path: str = "", output_files: list = [],
     output_extensions: list = [], correct_mode: bool = True,
     correct_filepath: str = "", path_to_scan: str = "", path_to_exclude: list = [],
-    formats: list = [], api_limit_exceed: bool = False, files_count: int = 0, final_output_path: str = "",
+    formats: list = [], scanoss_skipped: bool = False, files_count: int = 0, final_output_path: str = "",
     run_kb_msg: str = "", merge_by_folder: bool = True
 ) -> 'ScannerItem':
     """
@@ -218,8 +218,12 @@ def create_report_file(
         else:
             scan_item.set_cover_comment("(No OSS detected.)")
 
-    if api_limit_exceed:
-        scan_item.set_cover_comment("SCANOSS skipped (API limits)")
+    if scanoss_skipped:
+        is_kb_success = run_kb_msg != "" and "Completed" in run_kb_msg
+        if is_kb_success:
+            scan_item.set_cover_comment("SCANOSS replaced with KB")
+        else:
+            scan_item.set_cover_comment("SCANOSS skipped")
 
     if run_kb_msg:
         scan_item.set_cover_comment(run_kb_msg)
@@ -583,7 +587,7 @@ def run_scanners(
     spdx_downloads = {}
     result_log = {}
     scan_item = []
-    api_limit_exceed = False
+    scanoss_skipped = False
     kb_url, kb_token = resolve_kb_config(kb_url, kb_token)
 
     success, msg, output_path, output_files, output_extensions, formats = check_output_formats_v2(output_file_name, formats)
@@ -637,9 +641,11 @@ def run_scanners(
                 )
             excluded_files = set(excluded_files) if excluded_files else set()
             if selected_scanner in ['scanoss', ALL_MODE]:
-                scanoss_result, api_limit_exceed = run_scanoss_py(path_to_scan, output_path, formats, True, num_cores,
-                                                                  excluded_path_with_default_exclusion, excluded_files,
-                                                                  write_json_file, hide_progress, timeout=time_out)
+                scanoss_result, scanoss_skipped = run_scanoss_py(
+                    path_to_scan, output_path, formats, True, num_cores,
+                    excluded_path_with_default_exclusion, excluded_files,
+                    write_json_file, hide_progress, timeout=time_out
+                )
 
             run_kb_msg = ""
             if selected_scanner in SCANNER_TYPE:
@@ -664,7 +670,7 @@ def run_scanners(
                 scan_item = create_report_file(start_time, merged_result, license_list, scanoss_result, selected_scanner,
                                                print_matched_text, output_path, output_files, output_extensions, correct_mode,
                                                correct_filepath, path_to_scan, excluded_path_without_dot, formats,
-                                               api_limit_exceed, cnt_file_except_skipped, final_output_path, run_kb_msg,
+                                               scanoss_skipped, cnt_file_except_skipped, final_output_path, run_kb_msg,
                                                merge_by_folder)
             else:
                 print_help_msg_source_scanner()

--- a/src/fosslight_source/run_scanoss.py
+++ b/src/fosslight_source/run_scanoss.py
@@ -46,13 +46,13 @@ def run_scanoss_py(path_to_scan: str, output_path: str = "", format: list = [],
     """
 
     scanoss_file_list = []
-    api_limit_exceed = False
+    scanoss_skipped = False
     try:
         importlib_metadata.distribution("scanoss")
     except Exception as error:
         logger.warning(f"{error}. Skipping scan with scanoss.")
         logger.warning("Please install scanoss and dataclasses before run fosslight_source with scanoss option.")
-        return scanoss_file_list, api_limit_exceed
+        return scanoss_file_list, scanoss_skipped
 
     output_json_file = os.path.join(output_path, SCANOSS_OUTPUT_FILE)
     output_wfp_file = os.path.join(output_path, SCANOSS_RESULT_FILE)
@@ -76,6 +76,13 @@ def run_scanoss_py(path_to_scan: str, output_path: str = "", format: list = [],
             scanner.scan_folder_with_options(scan_dir=path_to_scan)
         captured_output = output_buffer.getvalue()
         api_limit_exceed = "due to service limits being exceeded" in captured_output
+        timeout_occurred = "The SCANOSS API request timed out" in captured_output
+        if timeout_occurred or api_limit_exceed:
+            scanoss_skipped = True
+            if timeout_occurred:
+                logger.debug("SCANOSS skipped (Timeout)")
+            elif api_limit_exceed:
+                logger.debug("SCANOSS skipped (API Limit Exceeded)")
 
         if os.path.isfile(output_json_file):
             logger.debug("|---SCANOSS Parsing")
@@ -100,4 +107,4 @@ def run_scanoss_py(path_to_scan: str, output_path: str = "", format: list = [],
 
     logger.info(f"|---Number of files detected with SCANOSS: {(len(scanoss_file_list))}")
 
-    return scanoss_file_list, api_limit_exceed
+    return scanoss_file_list, scanoss_skipped

--- a/src/fosslight_source/run_scanoss.py
+++ b/src/fosslight_source/run_scanoss.py
@@ -31,7 +31,8 @@ def get_scanoss_extra_info(scanned_result: dict) -> list:
 def run_scanoss_py(path_to_scan: str, output_path: str = "", format: list = [],
                    called_by_cli: bool = False, num_threads: int = -1,
                    path_to_exclude: list = [], excluded_files: set = None,
-                   write_json_file: bool = False, hide_progress: bool = False) -> Tuple[list, bool]:
+                   write_json_file: bool = False, hide_progress: bool = False,
+                   timeout: int = 120) -> Tuple[list, bool]:
     """
     Run scanoss.py for the given path.
 
@@ -40,6 +41,7 @@ def run_scanoss_py(path_to_scan: str, output_path: str = "", format: list = [],
     :param format: Output file format (not being used except when calling check_output_format).
     :param called_by_cli: if not called by cli, initialize logger.
     :param write_json_file: if requested, keep the raw files.
+    :param timeout: timeout in seconds for SCANOSS API request.
     :return scanoss_file_list: list of ScanItem (scanned result by files).
     """
 
@@ -66,7 +68,8 @@ def run_scanoss_py(path_to_scan: str, output_path: str = "", format: list = [],
             scan_output=output_json_file,
             scan_options=ScanType.SCAN_SNIPPETS.value,
             nb_threads=num_threads if num_threads > 0 else 10,
-            scanoss_settings=scanoss_settings
+            scanoss_settings=scanoss_settings,
+            timeout=timeout
         )
         output_buffer = io.StringIO()
         with contextlib.redirect_stdout(output_buffer), contextlib.redirect_stderr(output_buffer):


### PR DESCRIPTION
### Description
This PR supports passing the timeout (`-t`, `--timeout`) parameter to the SCANOSS scanner and improves error logging and reporting when a timeout occurs.

### Changes
- **SCANOSS Timeout Configuration**: Pass the `-t` value to the SCANOSS `Scanner` constructor (defaults to 120s, aligning with ScanCode).
- **Timeout Handling**:
  - Detect SCANOSS API timeouts in the output buffer.
  - Log a warning (`SCANOSS skipped (Timeout)`) and write detailed error info to the debug log.
  - Set appropriate Cover sheet comments (`SCANOSS replaced with KB` if KB succeeded, otherwise `SCANOSS skipped`).
- **Help Message**: Update the `-t` option description to show that it applies to both ScanCode and SCANOSS.
