### PR TITLE
Extract licenses from composer.json

### DIFF
--- a/src/fosslight_source/_scan_item.py
+++ b/src/fosslight_source/_scan_item.py
@@ -18,6 +18,7 @@ _notice_filename = ['licen[cs]e[s]?', 'notice[s]?', 'legal', 'copyright[s]?', 'c
 _manifest_filename = [
     r'.*\.pom$',
     r'package\.json$',
+    r'composer\.json$',
     r'setup\.py$',
     r'setup\.cfg$',
     r'pyproject\.toml$',

--- a/src/fosslight_source/run_manifest_extractor.py
+++ b/src/fosslight_source/run_manifest_extractor.py
@@ -74,6 +74,43 @@ def get_licenses_from_package_json(file_path: str) -> list[str]:
     return unique
 
 
+def get_licenses_from_composer_json(file_path: str) -> list[str]:
+    """Extract licenses from Composer ``composer.json`` ``license`` field.
+
+    Composer schema allows a string or an array of strings
+    (SPDX identifiers / expressions).
+    """
+    try:
+        with open(file_path, 'r', encoding='utf-8') as f:
+            data = json.load(f)
+    except Exception as ex:
+        logger.info(f"Failed to read composer.json {file_path}: {ex}")
+        return []
+
+    if not isinstance(data, dict):
+        return []
+
+    licenses: list[str] = []
+    license_field = data.get('license')
+
+    def append_license_value(value) -> None:
+        if isinstance(value, str):
+            token = value.strip()
+            if token:
+                licenses.extend(_split_spdx_expression(token))
+        elif isinstance(value, list):
+            for item in value:
+                append_license_value(item)
+
+    append_license_value(license_field)
+
+    unique: list[str] = []
+    for lic in licenses:
+        if lic not in unique:
+            unique.append(lic)
+    return unique
+
+
 def get_licenses_from_setup_cfg(file_path: str) -> list[str]:
     try:
         import configparser
@@ -322,6 +359,12 @@ def get_manifest_licenses(file_path: str) -> list[str]:
             return get_licenses_from_package_json(file_path)
         except Exception as ex:
             logger.info(f"Failed to extract license from package.json {file_path}: {ex}")
+            return []
+    elif os.path.basename(file_path).lower() == 'composer.json':
+        try:
+            return get_licenses_from_composer_json(file_path)
+        except Exception as ex:
+            logger.info(f"Failed to extract license from composer.json {file_path}: {ex}")
             return []
     elif os.path.basename(file_path).lower() == 'setup.cfg':
         try:

--- a/tests/test_manifest_composer.py
+++ b/tests/test_manifest_composer.py
@@ -1,0 +1,53 @@
+# Copyright (c) 2026 LG Electronics Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for composer.json manifest license extraction."""
+
+from fosslight_source._scan_item import is_manifest_file
+from fosslight_source.run_manifest_extractor import (
+    get_licenses_from_composer_json,
+    get_manifest_licenses,
+)
+
+
+def test_is_manifest_file_recognizes_composer_json():
+    assert is_manifest_file("/tmp/project/composer.json") is True
+    assert is_manifest_file("/tmp/project/Composer.JSON") is True
+
+
+def test_get_licenses_from_composer_json_string(tmp_path):
+    path = tmp_path / "composer.json"
+    path.write_text('{"name": "acme/demo", "license": "MIT"}', encoding="utf-8")
+    assert get_licenses_from_composer_json(str(path)) == ["MIT"]
+
+
+def test_get_licenses_from_composer_json_array(tmp_path):
+    path = tmp_path / "composer.json"
+    path.write_text(
+        '{"name": "acme/demo", "license": ["LGPL-2.1-only", "GPL-3.0-or-later"]}',
+        encoding="utf-8",
+    )
+    assert get_licenses_from_composer_json(str(path)) == [
+        "LGPL-2.1-only",
+        "GPL-3.0-or-later",
+    ]
+
+
+def test_get_licenses_from_composer_json_spdx_expression(tmp_path):
+    path = tmp_path / "composer.json"
+    path.write_text(
+        '{"name": "acme/demo", "license": "(MIT OR Apache-2.0)"}',
+        encoding="utf-8",
+    )
+    assert get_licenses_from_composer_json(str(path)) == ["MIT", "Apache-2.0"]
+
+
+def test_get_manifest_licenses_dispatches_composer_json(tmp_path):
+    path = tmp_path / "composer.json"
+    path.write_text('{"license": "BSD-3-Clause"}', encoding="utf-8")
+    assert get_manifest_licenses(str(path)) == ["BSD-3-Clause"]
+
+
+def test_get_licenses_from_composer_json_missing_license(tmp_path):
+    path = tmp_path / "composer.json"
+    path.write_text('{"name": "acme/demo"}', encoding="utf-8")
+    assert get_licenses_from_composer_json(str(path)) == []


### PR DESCRIPTION
* **New Features**
  * Added support for recognizing `composer.json` as a manifest file.
  * Added license extraction from `composer.json`, including string, array, and SPDX expression formats.
  * Duplicate licenses are removed, while missing or invalid license data is handled gracefully.