### PR TITLE
Fix unknown-spdx identifier

### DIFF
--- a/LICENSES/LicenseRef-MIT-like.txt
+++ b/LICENSES/LicenseRef-MIT-like.txt
@@ -1,7 +1,0 @@
-# This License text is the License text for testing unknown-spdx.
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/LICENSES/MIT.txt
+++ b/LICENSES/MIT.txt
@@ -1,5 +1,0 @@
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -8,18 +8,8 @@ SPDX-FileCopyrightText = "2021 LG Electronics"
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
-path = "tests/scancode_raw.json"
+path = "tests/**"
 precedence = "override"
-SPDX-FileCopyrightText = "2021 LG Electronics"
-SPDX-License-Identifier = "Apache-2.0"
-
-[[annotations]]
-path = "tests/json_result/**"
-SPDX-FileCopyrightText = "2021 LG Electronics"
-SPDX-License-Identifier = "Apache-2.0"
-
-[[annotations]]
-path = "tests/test_files/**"
 SPDX-FileCopyrightText = "2021 LG Electronics"
 SPDX-License-Identifier = "Apache-2.0"
 

--- a/src/fosslight_source/_parsing_scancode_file_item.py
+++ b/src/fosslight_source/_parsing_scancode_file_item.py
@@ -16,12 +16,17 @@ from typing import Tuple
 logger = logging.getLogger(constant.LOGGER_NAME)
 REMOVE_LICENSE = ["warranty-disclaimer"]
 find_word = re.compile(rb"SPDX-PackageDownloadLocation\s*:\s*(\S+)", re.IGNORECASE)
+SPDX_LICENSE_IDENTIFIER_PATTERN = re.compile(
+    r'SPDX-License-Identifier\s*:\s*([^\r\n]+)', re.IGNORECASE
+)
+LICENSE_REF_PREFIX_PATTERN = re.compile(r'^LicenseRef-', re.IGNORECASE)
 KEYWORD_SPDX_ID = r'SPDX-License-Identifier\s*[\S]+'
 KEYWORD_DOWNLOAD_LOC = r'DownloadLocation\s*[\S]+'
 KEYWORD_SCANCODE_UNKNOWN = "unknown-spdx"
+KEYWORD_UNKNOWN_LICENSE_REFERENCE = "unknown-license-reference"
 SPDX_REPLACE_WORDS = ["(", ")"]
-KEY_AND = r"(?<=\s)and(?=\s)"
-KEY_OR = r"(?<=\s)or(?=\s)"
+KEY_AND_OR = re.compile(r"(?<=\s)(?:and|or)(?=\s)", re.IGNORECASE)
+KEY_AND_OR_CAPTURE = re.compile(r"(?<=\s)(and|or)(?=\s)", re.IGNORECASE)
 GPL_LICENSE_PATTERN = r'((a|l)?gpl|gfdl)'  # GPL, LGPL, AGPL, GFDL
 SOURCE_EXTENSIONS = [
     '.java', '.cpp', '.c', '.cc', '.cxx', '.c++', '.h', '.hh', '.hpp', '.hxx', '.h++',
@@ -51,6 +56,27 @@ def is_gpl_family_license(licenses: list) -> bool:
 
 def should_remove_copyright_for_gpl_license_text(licenses: list, is_license_text: bool) -> bool:
     return is_license_text and is_gpl_family_license(licenses)
+
+
+def _expression_has_non_unknown_license_reference(license_expression: str) -> bool:
+    if not license_expression:
+        return False
+    for token in split_spdx_expression(license_expression.lower()):
+        token = token.strip()
+        if token and KEYWORD_UNKNOWN_LICENSE_REFERENCE not in token:
+            return True
+    return False
+
+
+def _matched_texts_with_other_licenses(matches: list) -> set:
+    """matched_text values that also produced a non-unknown-license-reference license."""
+    texts = set()
+    for matched_lic in matches or []:
+        matched_txt = matched_lic.get("matched_text") or ""
+        license_expression = matched_lic.get("license_expression") or ""
+        if matched_txt and _expression_has_non_unknown_license_reference(license_expression):
+            texts.add(matched_txt)
+    return texts
 
 
 def get_error_from_header(header_item: list) -> Tuple[bool, str]:
@@ -131,6 +157,14 @@ def parsing_scancode_32_earlier(
                             x.lower() for x in license_expression_list
                             if x is not None]
 
+                    matched_texts_with_other_licenses = {
+                        (lic_item.get("matched_text") or "")
+                        for lic_item in licenses
+                        if (lic_item.get("matched_text") or "")
+                        and (lic_item.get("key") or "")
+                        and KEYWORD_UNKNOWN_LICENSE_REFERENCE not in (lic_item.get("key") or "").lower()
+                    }
+
                     for lic_item in licenses:
                         license_value = ""
                         key = lic_item.get("key", "")
@@ -151,14 +185,17 @@ def parsing_scancode_32_earlier(
                             license_value = spdx.lower()
 
                         if license_value != "":
-                            if key == KEYWORD_SCANCODE_UNKNOWN:
-                                matched = re.search(
-                                    r'SPDX-License-Identifier\s*:\s*(\S+)',
-                                    lic_item.get("matched_text", ""), re.IGNORECASE
-                                )
+                            matched_txt = lic_item.get("matched_text", "")
+                            if (
+                                KEYWORD_UNKNOWN_LICENSE_REFERENCE in (key or "")
+                                and matched_txt in matched_texts_with_other_licenses
+                            ):
+                                continue
+                            if KEYWORD_SCANCODE_UNKNOWN in (key or ""):
+                                matched = SPDX_LICENSE_IDENTIFIER_PATTERN.search(matched_txt)
                                 if matched:
-                                    license_value = re.sub(
-                                        r'^LicenseRef-', '', matched.group(1), flags=re.IGNORECASE
+                                    license_value = LICENSE_REF_PREFIX_PATTERN.sub(
+                                        '', matched.group(1).strip()
                                     )
 
                             for word in replace_word:
@@ -169,13 +206,12 @@ def parsing_scancode_32_earlier(
                             # Add matched licenses
                             if "category" in lic_item:
                                 lic_category = lic_item["category"]
-                                if "matched_text" in lic_item:
-                                    lic_matched_text = lic_item["matched_text"]
-                                    lic_matched_key = license_value + lic_matched_text
+                                if matched_txt:
+                                    lic_matched_key = license_value + matched_txt
                                     if lic_matched_key in license_list:
                                         license_list[lic_matched_key].set_files(file_path)
                                     else:
-                                        lic_info = MatchedLicense(license_value, lic_category, lic_matched_text, file_path)
+                                        lic_info = MatchedLicense(license_value, lic_category, matched_txt, file_path)
                                         license_list[lic_matched_key] = lic_info
 
                         matched_rule = lic_item.get("matched_rule", {})
@@ -208,11 +244,194 @@ def parsing_scancode_32_earlier(
 
 
 def split_spdx_expression(spdx_string: str) -> list:
-    license = []
     for replace in SPDX_REPLACE_WORDS:
         spdx_string = spdx_string.replace(replace, "")
-    license = re.split(KEY_AND + "|" + KEY_OR, spdx_string)
-    return license
+    return [part.strip() for part in KEY_AND_OR.split(spdx_string) if part.strip()]
+
+
+def split_spdx_expression_with_ops(spdx_string: str) -> tuple[list[str], list[str]]:
+    """Return (tokens, ops) where ops[i] is AND/OR between tokens[i] and tokens[i+1]."""
+    for replace in SPDX_REPLACE_WORDS:
+        spdx_string = spdx_string.replace(replace, "")
+    parts = KEY_AND_OR_CAPTURE.split(spdx_string)
+    tokens = []
+    ops = []
+    for idx, part in enumerate(parts):
+        part = part.strip()
+        if idx % 2 == 0:
+            if part:
+                tokens.append(part)
+        else:
+            ops.append(part.upper())
+    # Drop trailing ops if last token was empty / missing
+    if len(ops) >= len(tokens):
+        ops = ops[: max(len(tokens) - 1, 0)]
+    return tokens, ops
+
+
+def join_licenses_with_ops(licenses: list[str], ops: list[str]) -> str:
+    if not licenses:
+        return ""
+    result = licenses[0]
+    for idx, license_name in enumerate(licenses[1:], start=0):
+        op = ops[idx] if idx < len(ops) else "AND"
+        result = f"{result} {op} {license_name}"
+    return result
+
+
+def _normalize_license_token(token: str) -> str:
+    token = (token or "").strip()
+    if not token:
+        return ""
+    license_expression_spdx = get_license_expression_spdx(token)
+    token = license_expression_spdx if license_expression_spdx else token
+    for word in replace_word:
+        token = token.replace(word, "")
+    return token
+
+
+def _declared_licenses_from_matched_text(matched_txt: str) -> tuple[list[str], list[str]]:
+    matched = SPDX_LICENSE_IDENTIFIER_PATTERN.search(matched_txt or "")
+    if not matched:
+        return [], []
+    declared = LICENSE_REF_PREFIX_PATTERN.sub('', matched.group(1).strip())
+    if not declared:
+        return [], []
+    return split_spdx_expression_with_ops(declared)
+
+
+def _build_unknown_spdx_replacement_queue(matches: list) -> list[str]:
+    """Ordered replacements for each unknown-spdx token in match order."""
+    queue = []
+    for matched_lic in matches or []:
+        expr = (matched_lic.get("license_expression") or "").lower()
+        if KEYWORD_SCANCODE_UNKNOWN not in expr:
+            continue
+        match_tokens, _ = split_spdx_expression_with_ops(expr)
+        declared_tokens, declared_ops = _declared_licenses_from_matched_text(
+            matched_lic.get("matched_text") or ""
+        )
+        if not declared_tokens:
+            continue
+
+        unknown_indexes = [
+            idx for idx, token in enumerate(match_tokens)
+            if KEYWORD_SCANCODE_UNKNOWN in token
+        ]
+        if not unknown_indexes:
+            continue
+
+        if len(match_tokens) == len(declared_tokens):
+            for idx in unknown_indexes:
+                queue.append(_normalize_license_token(declared_tokens[idx]) or declared_tokens[idx])
+            continue
+
+        if all(KEYWORD_SCANCODE_UNKNOWN in token for token in match_tokens):
+            if len(match_tokens) == 1:
+                norms = [_normalize_license_token(token) or token for token in declared_tokens]
+                queue.append(join_licenses_with_ops(norms, declared_ops))
+            else:
+                for i, _ in enumerate(unknown_indexes):
+                    declared = declared_tokens[i] if i < len(declared_tokens) else declared_tokens[-1]
+                    queue.append(_normalize_license_token(declared) or declared)
+            continue
+
+        # Mixed known + unknown tokens with different declared length:
+        # drop declared tokens that correspond to known match tokens, then assign the rest.
+        unused = list(declared_tokens)
+        for token in match_tokens:
+            if KEYWORD_SCANCODE_UNKNOWN in token:
+                continue
+            token_norm = (_normalize_license_token(token) or token).lower()
+            for idx, declared in enumerate(unused):
+                declared_norm = (_normalize_license_token(declared) or declared).lower()
+                if declared_norm == token_norm or declared.lower() == token.lower():
+                    unused.pop(idx)
+                    break
+        for _ in unknown_indexes:
+            if not unused:
+                break
+            declared = unused.pop(0)
+            queue.append(_normalize_license_token(declared) or declared)
+    return queue
+
+
+def _should_suppress_unknown_license_reference(
+    matches: list, matched_texts_with_other_licenses: set
+) -> bool:
+    for matched_lic in matches or []:
+        expr = (matched_lic.get("license_expression") or "").lower()
+        matched_txt = matched_lic.get("matched_text") or ""
+        if (
+            KEYWORD_UNKNOWN_LICENSE_REFERENCE in expr
+            and matched_txt in matched_texts_with_other_licenses
+        ):
+            return True
+    return False
+
+
+def build_comment_from_detected_expression(
+    detected_expression: str,
+    matches: list,
+    matched_texts_with_other_licenses: set,
+) -> str:
+    """Rebuild comment from detected expression, preserving AND/OR operators."""
+    if not detected_expression:
+        return ""
+
+    expr = detected_expression
+    if KEYWORD_SCANCODE_UNKNOWN not in expr.lower():
+        expr = re.sub(
+            r'licenseref-scancode-unknown-spdx',
+            KEYWORD_SCANCODE_UNKNOWN,
+            expr,
+            flags=re.IGNORECASE,
+        )
+        expr = re.sub(
+            r'licenseref-scancode-unknown-license-reference',
+            KEYWORD_UNKNOWN_LICENSE_REFERENCE,
+            expr,
+            flags=re.IGNORECASE,
+        )
+
+    replacements = _build_unknown_spdx_replacement_queue(matches)
+    suppress_ulr = _should_suppress_unknown_license_reference(
+        matches, matched_texts_with_other_licenses
+    )
+    tokens, ops = split_spdx_expression_with_ops(expr)
+
+    kept_licenses = []
+    kept_ops = []
+    repl_idx = 0
+    for token_idx, token in enumerate(tokens):
+        token = token.strip()
+        if not token:
+            continue
+        token_lower = token.lower()
+        skip = False
+        output = token
+
+        if KEYWORD_UNKNOWN_LICENSE_REFERENCE in token_lower:
+            skip = suppress_ulr
+        elif KEYWORD_SCANCODE_UNKNOWN in token_lower:
+            if repl_idx < len(replacements):
+                output = replacements[repl_idx]
+                repl_idx += 1
+            else:
+                skip = True
+        else:
+            output = _normalize_license_token(token) or token
+            if output.lower() in REMOVE_LICENSE:
+                skip = True
+
+        if skip or not output:
+            continue
+        if kept_licenses:
+            op_idx = token_idx - 1
+            kept_ops.append(ops[op_idx] if 0 <= op_idx < len(ops) else "AND")
+        kept_licenses.append(output)
+
+    return join_licenses_with_ops(kept_licenses, kept_ops)
 
 
 def get_license_expression_spdx(license_expression: str) -> str:
@@ -265,10 +484,15 @@ def parsing_scancode_32_later(
                             pass
                         copyright_value_list.append(copyright_data)
                 license_detected = []
+                resolved_unknown_spdx = False
                 licenses = file.get("license_detections", [])
                 # Keep license and/or copyright findings; UI keeps finding-less files too.
                 if not licenses and not copyright_value_list and not ui_mode:
                     continue
+                all_matches = []
+                for lic in licenses or []:
+                    all_matches.extend(lic.get("matches") or [])
+                matched_texts_with_other_licenses = _matched_texts_with_other_licenses(all_matches)
                 for lic in licenses or []:
                     matched_lic_list = lic.get("matches", [])
                     for matched_lic in matched_lic_list:
@@ -276,24 +500,35 @@ def parsing_scancode_32_later(
                         matched_txt = matched_lic.get("matched_text", "")
                         if found_lic_list:
                             found_lic_list = found_lic_list.lower()
+                            if KEYWORD_SCANCODE_UNKNOWN in found_lic_list:
+                                matched = SPDX_LICENSE_IDENTIFIER_PATTERN.search(matched_txt)
+                                if matched:
+                                    declared = LICENSE_REF_PREFIX_PATTERN.sub(
+                                        '', matched.group(1).strip()
+                                    )
+                                    if declared:
+                                        found_lic_list = declared
+                                        resolved_unknown_spdx = True
                             for found_lic in split_spdx_expression(found_lic_list):
                                 if found_lic:
                                     found_lic = found_lic.strip()
                                     if found_lic in REMOVE_LICENSE:
                                         continue
-                                    elif found_lic == KEYWORD_SCANCODE_UNKNOWN:
-                                        matched = re.search(
-                                            r'SPDX-License-Identifier\s*:\s*(\S+)',
-                                            matched_txt, re.IGNORECASE
-                                        )
+                                    if (
+                                        KEYWORD_UNKNOWN_LICENSE_REFERENCE in found_lic.lower()
+                                        and matched_txt in matched_texts_with_other_licenses
+                                    ):
+                                        continue
+                                    if KEYWORD_SCANCODE_UNKNOWN in found_lic.lower():
+                                        matched = SPDX_LICENSE_IDENTIFIER_PATTERN.search(matched_txt)
                                         if matched:
-                                            found_lic = re.sub(
-                                                r'^LicenseRef-', '', matched.group(1), flags=re.IGNORECASE
+                                            found_lic = LICENSE_REF_PREFIX_PATTERN.sub(
+                                                '', matched.group(1).strip()
                                             )
-                                    license_expression_spdx = get_license_expression_spdx(found_lic)
-                                    found_lic = license_expression_spdx if license_expression_spdx else found_lic
-                                    for word in replace_word:
-                                        found_lic = found_lic.replace(word, "")
+                                            resolved_unknown_spdx = True
+                                    found_lic = _normalize_license_token(found_lic) or found_lic
+                                    if not found_lic:
+                                        continue
                                     if matched_txt:
                                         lic_matched_key = found_lic + matched_txt
                                         if lic_matched_key in license_list:
@@ -317,12 +552,24 @@ def parsing_scancode_32_later(
                     result_item.copyright = copyright_value_list
 
                 if len(license_detected) > 1:
-                    license_expression_spdx = file.get("detected_license_expression_spdx", "")
-                    license_expression = file.get("detected_license_expression", "")
-                    if license_expression_spdx:
-                        license_expression = license_expression_spdx
-                    if license_expression and "OR" in license_expression:
-                        result_item.comment = license_expression
+                    detected_expression = file.get("detected_license_expression", "") or ""
+                    detected_expression_spdx = file.get("detected_license_expression_spdx", "") or ""
+                    if (
+                        resolved_unknown_spdx
+                        or KEYWORD_SCANCODE_UNKNOWN in detected_expression.lower()
+                        or "licenseref-scancode-unknown-spdx" in detected_expression_spdx.lower()
+                    ):
+                        # Prefer non-SPDX expression so unknown-spdx tokens map cleanly.
+                        source_expression = detected_expression or detected_expression_spdx
+                        result_item.comment = build_comment_from_detected_expression(
+                            source_expression,
+                            all_matches,
+                            matched_texts_with_other_licenses,
+                        )
+                    else:
+                        license_expression = detected_expression_spdx or detected_expression
+                        if license_expression and "OR" in license_expression:
+                            result_item.comment = license_expression
 
                 scancode_file_item.append(result_item)
             except Exception as ex:

--- a/src/fosslight_source/_parsing_scancode_file_item.py
+++ b/src/fosslight_source/_parsing_scancode_file_item.py
@@ -20,6 +20,8 @@ SPDX_LICENSE_IDENTIFIER_PATTERN = re.compile(
     r'SPDX-License-Identifier\s*:\s*([^\r\n]+)', re.IGNORECASE
 )
 LICENSE_REF_PREFIX_PATTERN = re.compile(r'^LicenseRef-', re.IGNORECASE)
+# Trailing closers from block/HTML comments, e.g. "MIT */" or "MIT -->"
+SPDX_COMMENT_TRAILER_PATTERN = re.compile(r'\s*(?:\*/|-->)\s*$')
 KEYWORD_SPDX_ID = r'SPDX-License-Identifier\s*[\S]+'
 KEYWORD_DOWNLOAD_LOC = r'DownloadLocation\s*[\S]+'
 KEYWORD_SCANCODE_UNKNOWN = "unknown-spdx"
@@ -192,11 +194,9 @@ def parsing_scancode_32_earlier(
                             ):
                                 continue
                             if KEYWORD_SCANCODE_UNKNOWN in (key or ""):
-                                matched = SPDX_LICENSE_IDENTIFIER_PATTERN.search(matched_txt)
-                                if matched:
-                                    license_value = LICENSE_REF_PREFIX_PATTERN.sub(
-                                        '', matched.group(1).strip()
-                                    )
+                                declared = _extract_spdx_declared_expression(matched_txt)
+                                if declared:
+                                    license_value = declared
 
                             for word in replace_word:
                                 if word in license_value:
@@ -279,6 +279,39 @@ def join_licenses_with_ops(licenses: list[str], ops: list[str]) -> str:
     return result
 
 
+def _clean_spdx_declaration(raw: str) -> str:
+    """Strip whitespace and trailing comment terminators from a captured declaration."""
+    cleaned = (raw or "").strip()
+    if not cleaned:
+        return ""
+    return SPDX_COMMENT_TRAILER_PATTERN.sub('', cleaned).strip()
+
+
+def _strip_license_ref_prefix(token: str) -> str:
+    return LICENSE_REF_PREFIX_PATTERN.sub('', (token or "").strip())
+
+
+def _extract_spdx_declared_expression(matched_txt: str) -> str:
+    """
+    Extract SPDX-License-Identifier value from matched_text.
+
+    - Removes trailing comment closers (*/ , -->)
+    - Strips LicenseRef- from each AND/OR token
+    """
+    matched = SPDX_LICENSE_IDENTIFIER_PATTERN.search(matched_txt or "")
+    if not matched:
+        return ""
+    declared = _clean_spdx_declaration(matched.group(1))
+    if not declared:
+        return ""
+    tokens, ops = split_spdx_expression_with_ops(declared)
+    cleaned_tokens = [_strip_license_ref_prefix(token) for token in tokens]
+    cleaned_tokens = [token for token in cleaned_tokens if token]
+    if not cleaned_tokens:
+        return ""
+    return join_licenses_with_ops(cleaned_tokens, ops)
+
+
 def _normalize_license_token(token: str) -> str:
     token = (token or "").strip()
     if not token:
@@ -291,10 +324,7 @@ def _normalize_license_token(token: str) -> str:
 
 
 def _declared_licenses_from_matched_text(matched_txt: str) -> tuple[list[str], list[str]]:
-    matched = SPDX_LICENSE_IDENTIFIER_PATTERN.search(matched_txt or "")
-    if not matched:
-        return [], []
-    declared = LICENSE_REF_PREFIX_PATTERN.sub('', matched.group(1).strip())
+    declared = _extract_spdx_declared_expression(matched_txt)
     if not declared:
         return [], []
     return split_spdx_expression_with_ops(declared)
@@ -501,14 +531,10 @@ def parsing_scancode_32_later(
                         if found_lic_list:
                             found_lic_list = found_lic_list.lower()
                             if KEYWORD_SCANCODE_UNKNOWN in found_lic_list:
-                                matched = SPDX_LICENSE_IDENTIFIER_PATTERN.search(matched_txt)
-                                if matched:
-                                    declared = LICENSE_REF_PREFIX_PATTERN.sub(
-                                        '', matched.group(1).strip()
-                                    )
-                                    if declared:
-                                        found_lic_list = declared
-                                        resolved_unknown_spdx = True
+                                declared = _extract_spdx_declared_expression(matched_txt)
+                                if declared:
+                                    found_lic_list = declared
+                                    resolved_unknown_spdx = True
                             for found_lic in split_spdx_expression(found_lic_list):
                                 if found_lic:
                                     found_lic = found_lic.strip()
@@ -520,12 +546,11 @@ def parsing_scancode_32_later(
                                     ):
                                         continue
                                     if KEYWORD_SCANCODE_UNKNOWN in found_lic.lower():
-                                        matched = SPDX_LICENSE_IDENTIFIER_PATTERN.search(matched_txt)
-                                        if matched:
-                                            found_lic = LICENSE_REF_PREFIX_PATTERN.sub(
-                                                '', matched.group(1).strip()
-                                            )
+                                        declared = _extract_spdx_declared_expression(matched_txt)
+                                        if declared:
+                                            found_lic = declared
                                             resolved_unknown_spdx = True
+                                    found_lic = _strip_license_ref_prefix(found_lic)
                                     found_lic = _normalize_license_token(found_lic) or found_lic
                                     if not found_lic:
                                         continue

--- a/src/fosslight_source/_parsing_scancode_file_item.py
+++ b/src/fosslight_source/_parsing_scancode_file_item.py
@@ -153,13 +153,14 @@ def parsing_scancode_32_earlier(
 
                         if license_value != "":
                             if key == KEYWORD_SCANCODE_UNKNOWN:
-                                try:
-                                    matched_txt = lic_item.get("matched_text", "").lower()
-                                    matched = regex.search(matched_txt)
-                                    if matched:
-                                        license_value = str(matched.group())
-                                except Exception:
-                                    pass
+                                matched = re.search(
+                                    r'SPDX-License-Identifier\s*:\s*(\S+)',
+                                    lic_item.get("matched_text", ""), re.IGNORECASE
+                                )
+                                if matched:
+                                    license_value = re.sub(
+                                        r'^LicenseRef-', '', matched.group(1), flags=re.IGNORECASE
+                                    )
 
                             for word in replace_word:
                                 if word in license_value:
@@ -282,12 +283,14 @@ def parsing_scancode_32_later(
                                     if found_lic in REMOVE_LICENSE:
                                         continue
                                     elif found_lic == KEYWORD_SCANCODE_UNKNOWN:
-                                        try:
-                                            matched = regex.search(matched_txt.lower())
-                                            if matched:
-                                                found_lic = str(matched.group())
-                                        except Exception:
-                                            pass
+                                        matched = re.search(
+                                            r'SPDX-License-Identifier\s*:\s*(\S+)',
+                                            matched_txt, re.IGNORECASE
+                                        )
+                                        if matched:
+                                            found_lic = re.sub(
+                                                r'^LicenseRef-', '', matched.group(1), flags=re.IGNORECASE
+                                            )
                                     license_expression_spdx = get_license_expression_spdx(found_lic)
                                     found_lic = license_expression_spdx if license_expression_spdx else found_lic
                                     for word in replace_word:

--- a/src/fosslight_source/_parsing_scancode_file_item.py
+++ b/src/fosslight_source/_parsing_scancode_file_item.py
@@ -420,6 +420,28 @@ def _serialize_license_expr_node(node, is_right_child: bool = False) -> str:
     return rendered
 
 
+def _omit_parens_for_two_license_expression(expression: str) -> str:
+    """
+    Drop parentheses when the expression only connects two licenses.
+
+    Example: ``(Apache-2.0 OR MIT)`` -> ``Apache-2.0 OR MIT``.
+    Keep parentheses when three or more licenses need grouping.
+    """
+    expr = (expression or "").strip()
+    if not expr or "(" not in expr:
+        return expr
+    tokens = _tokenize_license_expression(expr)
+    license_tokens = [
+        token for token in tokens
+        if token not in ("(", ")") and token.upper() not in ("AND", "OR")
+    ]
+    if len(license_tokens) != 2:
+        return expr
+    return " ".join(
+        token for token in tokens if token not in ("(", ")")
+    )
+
+
 def _clean_spdx_declaration(raw: str) -> str:
     """Strip whitespace and trailing comment terminators from a captured declaration."""
     cleaned = (raw or "").strip()
@@ -583,7 +605,9 @@ def build_comment_from_detected_expression(
     transformed = _transform_license_expr_node(
         tree, replacements, [0], suppress_ulr
     )
-    return _serialize_license_expr_node(transformed)
+    return _omit_parens_for_two_license_expression(
+        _serialize_license_expr_node(transformed)
+    )
 
 
 def get_license_expression_spdx(license_expression: str) -> str:
@@ -716,7 +740,9 @@ def parsing_scancode_32_later(
                     else:
                         license_expression = detected_expression_spdx or detected_expression
                         if license_expression and "OR" in license_expression:
-                            result_item.comment = license_expression
+                            result_item.comment = _omit_parens_for_two_license_expression(
+                                license_expression
+                            )
 
                 scancode_file_item.append(result_item)
             except Exception as ex:

--- a/src/fosslight_source/_parsing_scancode_file_item.py
+++ b/src/fosslight_source/_parsing_scancode_file_item.py
@@ -731,12 +731,14 @@ def parsing_scancode_32_later(
                         or "licenseref-scancode-unknown-spdx" in detected_expression_spdx.lower()
                     ):
                         # Prefer non-SPDX expression so unknown-spdx tokens map cleanly.
+                        # Comment only for dual-license style expressions that include OR.
                         source_expression = detected_expression or detected_expression_spdx
-                        result_item.comment = build_comment_from_detected_expression(
-                            source_expression,
-                            all_matches,
-                            matched_texts_with_other_licenses,
-                        )
+                        if source_expression and "OR" in source_expression.upper():
+                            result_item.comment = build_comment_from_detected_expression(
+                                source_expression,
+                                all_matches,
+                                matched_texts_with_other_licenses,
+                            )
                     else:
                         license_expression = detected_expression_spdx or detected_expression
                         if license_expression and "OR" in license_expression:

--- a/src/fosslight_source/_parsing_scancode_file_item.py
+++ b/src/fosslight_source/_parsing_scancode_file_item.py
@@ -279,6 +279,147 @@ def join_licenses_with_ops(licenses: list[str], ops: list[str]) -> str:
     return result
 
 
+def _merge_ops_across_skip(ops_between: list[str]) -> str:
+    """
+    When intermediate tokens are skipped and parentheses are not considered,
+    keep the operator immediately before the next kept token (직전 연산자).
+
+    SPDX AND/OR are left-associative with equal precedence, so
+    ``A OR B AND C`` means ``(A OR B) AND C``. Removing B yields ``A AND C``.
+    """
+    normalized = [op.upper() for op in ops_between if op]
+    if not normalized:
+        return "AND"
+    return normalized[-1]
+
+
+def _kept_tokens_with_merged_ops(
+    tokens: list[str], ops: list[str]
+) -> tuple[list[str], list[str]]:
+    """Keep non-empty tokens; use the 직전 operator across skipped positions."""
+    kept_tokens = []
+    kept_ops = []
+    last_kept_idx = None
+    for idx, token in enumerate(tokens):
+        token = (token or "").strip()
+        if not token:
+            continue
+        if last_kept_idx is not None:
+            # ops[i] sits between tokens[i] and tokens[i+1]
+            kept_ops.append(_merge_ops_across_skip(ops[last_kept_idx:idx]))
+        kept_tokens.append(token)
+        last_kept_idx = idx
+    return kept_tokens, kept_ops
+
+
+_LICENSE_EXPR_TOKEN_PATTERN = re.compile(
+    r"\(|\)|(?i:\band\b)|(?i:\bor\b)|[^\s()]+"
+)
+
+
+class _LicenseLeaf:
+    def __init__(self, value: str) -> None:
+        self.value = value
+
+
+class _LicenseBinOp:
+    def __init__(self, op: str, left, right) -> None:
+        self.op = op
+        self.left = left
+        self.right = right
+
+
+def _tokenize_license_expression(expression: str) -> list[str]:
+    return _LICENSE_EXPR_TOKEN_PATTERN.findall(expression or "")
+
+
+def _parse_license_expression_tokens(tokens: list[str]):
+    """
+    Parse SPDX-like license expression.
+
+    AND/OR have equal precedence and are left-associative.
+    Parentheses change grouping.
+    """
+    pos = 0
+
+    def primary():
+        nonlocal pos
+        if pos >= len(tokens):
+            return None
+        if tokens[pos] == "(":
+            pos += 1
+            node = parse_expr()
+            if pos < len(tokens) and tokens[pos] == ")":
+                pos += 1
+            return node
+        token = tokens[pos]
+        pos += 1
+        return _LicenseLeaf(token)
+
+    def parse_expr():
+        nonlocal pos
+        node = primary()
+        while pos < len(tokens) and tokens[pos].upper() in ("AND", "OR"):
+            op = tokens[pos].upper()
+            pos += 1
+            right = primary()
+            if right is None:
+                break
+            node = _LicenseBinOp(op, node, right)
+        return node
+
+    return parse_expr()
+
+
+def _transform_license_expr_node(
+    node,
+    replacements: list[str],
+    repl_idx: list[int],
+    suppress_ulr: bool,
+):
+    if node is None:
+        return None
+    if isinstance(node, _LicenseLeaf):
+        token = node.value
+        token_lower = token.lower()
+        if KEYWORD_UNKNOWN_LICENSE_REFERENCE in token_lower:
+            return None if suppress_ulr else _LicenseLeaf(token)
+        if KEYWORD_SCANCODE_UNKNOWN in token_lower:
+            if repl_idx[0] < len(replacements):
+                replacement = replacements[repl_idx[0]]
+                repl_idx[0] += 1
+                return _parse_license_expression_tokens(
+                    _tokenize_license_expression(replacement)
+                )
+            return None
+        output = _normalize_license_token(token) or token
+        if not output or output.lower() in REMOVE_LICENSE:
+            return None
+        return _LicenseLeaf(output)
+
+    left = _transform_license_expr_node(node.left, replacements, repl_idx, suppress_ulr)
+    right = _transform_license_expr_node(node.right, replacements, repl_idx, suppress_ulr)
+    if left is None:
+        return right
+    if right is None:
+        return left
+    return _LicenseBinOp(node.op, left, right)
+
+
+def _serialize_license_expr_node(node, is_right_child: bool = False) -> str:
+    if node is None:
+        return ""
+    if isinstance(node, _LicenseLeaf):
+        return node.value
+    left = _serialize_license_expr_node(node.left, False)
+    right = _serialize_license_expr_node(node.right, True)
+    rendered = f"{left} {node.op} {right}"
+    # Equal-precedence left-assoc: parenthesize right BinOp groups.
+    if is_right_child and isinstance(node, _LicenseBinOp):
+        return f"({rendered})"
+    return rendered
+
+
 def _clean_spdx_declaration(raw: str) -> str:
     """Strip whitespace and trailing comment terminators from a captured declaration."""
     cleaned = (raw or "").strip()
@@ -306,10 +447,10 @@ def _extract_spdx_declared_expression(matched_txt: str) -> str:
         return ""
     tokens, ops = split_spdx_expression_with_ops(declared)
     cleaned_tokens = [_strip_license_ref_prefix(token) for token in tokens]
-    cleaned_tokens = [token for token in cleaned_tokens if token]
-    if not cleaned_tokens:
+    kept_tokens, kept_ops = _kept_tokens_with_merged_ops(cleaned_tokens, ops)
+    if not kept_tokens:
         return ""
-    return join_licenses_with_ops(cleaned_tokens, ops)
+    return join_licenses_with_ops(kept_tokens, kept_ops)
 
 
 def _normalize_license_token(token: str) -> str:
@@ -405,7 +546,15 @@ def build_comment_from_detected_expression(
     matches: list,
     matched_texts_with_other_licenses: set,
 ) -> str:
-    """Rebuild comment from detected expression, preserving AND/OR operators."""
+    """
+    Rebuild comment from detected expression.
+
+    Preserves AND/OR and parentheses. SPDX AND/OR are left-associative with
+    equal precedence, so without parentheses ``A OR B AND C`` means
+    ``(A OR B) AND C``. Removing ``B`` therefore yields ``A AND C`` (직전 연산자).
+    Explicit parentheses are honored, e.g.
+    ``A OR (B AND C)`` with ``B`` removed becomes ``A OR C``.
+    """
     if not detected_expression:
         return ""
 
@@ -428,40 +577,13 @@ def build_comment_from_detected_expression(
     suppress_ulr = _should_suppress_unknown_license_reference(
         matches, matched_texts_with_other_licenses
     )
-    tokens, ops = split_spdx_expression_with_ops(expr)
-
-    kept_licenses = []
-    kept_ops = []
-    repl_idx = 0
-    for token_idx, token in enumerate(tokens):
-        token = token.strip()
-        if not token:
-            continue
-        token_lower = token.lower()
-        skip = False
-        output = token
-
-        if KEYWORD_UNKNOWN_LICENSE_REFERENCE in token_lower:
-            skip = suppress_ulr
-        elif KEYWORD_SCANCODE_UNKNOWN in token_lower:
-            if repl_idx < len(replacements):
-                output = replacements[repl_idx]
-                repl_idx += 1
-            else:
-                skip = True
-        else:
-            output = _normalize_license_token(token) or token
-            if output.lower() in REMOVE_LICENSE:
-                skip = True
-
-        if skip or not output:
-            continue
-        if kept_licenses:
-            op_idx = token_idx - 1
-            kept_ops.append(ops[op_idx] if 0 <= op_idx < len(ops) else "AND")
-        kept_licenses.append(output)
-
-    return join_licenses_with_ops(kept_licenses, kept_ops)
+    tree = _parse_license_expression_tokens(_tokenize_license_expression(expr))
+    if tree is None:
+        return ""
+    transformed = _transform_license_expr_node(
+        tree, replacements, [0], suppress_ulr
+    )
+    return _serialize_license_expr_node(transformed)
 
 
 def get_license_expression_spdx(license_expression: str) -> str:

--- a/src/fosslight_source/_parsing_scancode_file_item.py
+++ b/src/fosslight_source/_parsing_scancode_file_item.py
@@ -15,7 +15,6 @@ from typing import Tuple
 
 logger = logging.getLogger(constant.LOGGER_NAME)
 REMOVE_LICENSE = ["warranty-disclaimer"]
-regex = re.compile(r'licenseref-([a-z0-9\.\-]+)', re.IGNORECASE)
 find_word = re.compile(rb"SPDX-PackageDownloadLocation\s*:\s*(\S+)", re.IGNORECASE)
 KEYWORD_SPDX_ID = r'SPDX-License-Identifier\s*[\S]+'
 KEYWORD_DOWNLOAD_LOC = r'DownloadLocation\s*[\S]+'
@@ -224,7 +223,7 @@ def get_license_expression_spdx(license_expression: str) -> str:
         result = build_spdx_license_expression(license_expression.strip())
         if result is None:
             return ""
-        if regex.match(result):
+        if isinstance(result, str) and result.lower().startswith("licenseref-"):
             return ""
         return result
     except Exception:

--- a/tests/test_files/dual.txt
+++ b/tests/test_files/dual.txt
@@ -1,5 +1,5 @@
 # Copyright (c) 2020 LG Electronics Inc.
 # Copyright (c) 2021 LG Electronics Inc.
 # REUSE-IgnoreStart
-# SPDX-License-Identifier: GPL-2.0 or MIT
+# SPDX-License-Identifier: GPL-2.0 or MIT-like
 # REUSE-IgnoreEnd

--- a/tests/test_files/dual_unknow.py
+++ b/tests/test_files/dual_unknow.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # Copyright (c) 2020 LG Electronics Inc.
-# SPDX-License-Identifier: NEW AND DApache-2.0
+# SPDX-License-Identifier: NEW OR DApache-2.0
 
 # SPDX-PackageDownloadLocation: https://dummy_url_for_test.com
 # The code is not licensed under GPL-2.0.

--- a/tests/test_files/run_scancode.py
+++ b/tests/test_files/run_scancode.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # Copyright (c) 2020 LG Electronics Inc.
-# SPDX-License-Identifier: NEW AND DApache-2.0
+# SPDX-License-Identifier: LicenseRef-NEW AND LicenseRef-TEST
 
 # SPDX-PackageDownloadLocation: https://dummy_url_for_test.com
 # The code is not licensed under GPL-2.0.

--- a/tests/test_files/temp.cpp
+++ b/tests/test_files/temp.cpp
@@ -1,6 +1,6 @@
 /*
   * SPDX-FileCopyrightText: Copyright 2022 LG Electronics Inc.
-  * SPDX-License-Identifier: Apache-2.0
+  * SPDX-License-Identifier: Apache-2.0 OR MIT
   * DownloadLocation: https://github.com/browserify/acorn-node
  */
 #include <iostream>

--- a/tests/test_files/test_unknown_spdx.txt
+++ b/tests/test_files/test_unknown_spdx.txt
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # Copyright (c) 2020 LG Electronics Inc.
-# SPDX-License-Identifier: LicenseRef-MIT-like
+# SPDX-License-Identifier: MIT-like
 
 import os
 

--- a/tests/test_parsing_unknown_spdx.py
+++ b/tests/test_parsing_unknown_spdx.py
@@ -1,0 +1,218 @@
+# Copyright (c) 2026 LG Electronics Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for unknown-spdx restoration and SPDX declaration cleanup."""
+
+import pytest
+
+from fosslight_source._parsing_scancode_file_item import (
+    _extract_spdx_declared_expression,
+    _declared_licenses_from_matched_text,
+    build_comment_from_detected_expression,
+    parsing_scancode_32_earlier,
+    parsing_scancode_32_later,
+    _matched_texts_with_other_licenses,
+)
+
+
+@pytest.mark.parametrize(
+    ("matched_text", "expected"),
+    [
+        ("// SPDX-License-Identifier: MIT", "MIT"),
+        ("/* SPDX-License-Identifier: MIT */", "MIT"),
+        ("<!-- SPDX-License-Identifier: MIT -->", "MIT"),
+        ("# SPDX-License-Identifier: LicenseRef-MIT-like", "MIT-like"),
+        (
+            "# SPDX-License-Identifier: LicenseRef-Foo AND LicenseRef-Bar",
+            "Foo AND Bar",
+        ),
+        (
+            "/* SPDX-License-Identifier: LicenseRef-Foo OR LicenseRef-Bar */",
+            "Foo OR Bar",
+        ),
+    ],
+)
+def test_extract_spdx_declared_expression(matched_text, expected):
+    assert _extract_spdx_declared_expression(matched_text) == expected
+
+
+def test_declared_licenses_strips_licenseref_per_token():
+    tokens, ops = _declared_licenses_from_matched_text(
+        "# SPDX-License-Identifier: LicenseRef-Foo AND LicenseRef-Bar"
+    )
+    assert tokens == ["Foo", "Bar"]
+    assert ops == ["AND"]
+
+
+@pytest.mark.parametrize(
+    ("matched_text", "expected_license"),
+    [
+        ("// SPDX-License-Identifier: UNLICENSED", "UNLICENSED"),
+        ("// SPDX-License-Identifier: LicenseRef-MIT-like", "MIT-like"),
+        ("/* SPDX-License-Identifier: MIT */", "MIT"),
+        ("<!-- SPDX-License-Identifier: Apache-2.0 -->", "Apache-2.0"),
+    ],
+)
+def test_unknown_spdx_uses_declared_identifier(matched_text, expected_license):
+    scancode_file_list = [{
+        "path": "example.sol",
+        "type": "file",
+        "license_detections": [{
+            "matches": [{
+                "license_expression": "unknown-spdx",
+                "matched_text": matched_text,
+            }],
+        }],
+        "copyrights": [],
+    }]
+
+    success, results, _messages, _license_list = parsing_scancode_32_later(scancode_file_list)
+
+    assert success is True
+    assert results[0].licenses == [expected_license]
+
+
+def test_unknown_spdx_in_compound_expression_splits_and_or():
+    scancode_file_list = [{
+        "path": "dual.txt",
+        "type": "file",
+        "detected_license_expression": "gpl-2.0 OR unknown-spdx",
+        "license_detections": [{
+            "matches": [{
+                "license_expression": "gpl-2.0 OR unknown-spdx",
+                "matched_text": "# SPDX-License-Identifier: GPL-2.0 or MIT-like",
+            }],
+        }],
+        "copyrights": [],
+    }]
+
+    success, results, _messages, _ = parsing_scancode_32_later(scancode_file_list)
+
+    assert success is True
+    assert results[0].licenses == ["GPL-2.0", "MIT-like"]
+    assert results[0].comment == "GPL-2.0 OR MIT-like"
+
+
+def test_unknown_spdx_comment_preserves_and_or_from_detected_expression():
+    matched_same = "# The code is not licensed under GPL-2.0."
+    scancode_file_list = [{
+        "path": "dual_unknow.py",
+        "type": "file",
+        "detected_license_expression": (
+            "(unknown-spdx OR unknown-spdx) AND unknown-license-reference AND gpl-2.0"
+        ),
+        "license_detections": [{
+            "matches": [
+                {
+                    "license_expression": "unknown-spdx OR unknown-spdx",
+                    "matched_text": "# SPDX-License-Identifier: NEW OR DApache-2.0",
+                },
+                {
+                    "license_expression": "unknown-license-reference",
+                    "matched_text": matched_same,
+                },
+                {
+                    "license_expression": "gpl-2.0",
+                    "matched_text": matched_same,
+                },
+            ],
+        }],
+        "copyrights": [],
+    }]
+
+    success, results, _messages, _ = parsing_scancode_32_later(scancode_file_list)
+
+    assert success is True
+    assert results[0].licenses == ["NEW", "DApache-2.0", "GPL-2.0"]
+    assert "unknown-license-reference" not in [lic.lower() for lic in results[0].licenses]
+    assert results[0].comment == "NEW OR DApache-2.0 AND GPL-2.0"
+
+
+def test_unknown_license_reference_suppressed_when_same_matched_text_has_other_license():
+    matched_same = "# The code is not licensed under GPL-2.0."
+    scancode_file_list = [{
+        "path": "sample.py",
+        "type": "file",
+        "license_detections": [{
+            "matches": [
+                {
+                    "license_expression": "unknown-license-reference",
+                    "matched_text": matched_same,
+                },
+                {
+                    "license_expression": "gpl-2.0",
+                    "matched_text": matched_same,
+                },
+            ],
+        }],
+        "copyrights": [],
+    }]
+
+    success, results, _messages, _ = parsing_scancode_32_later(scancode_file_list)
+
+    assert success is True
+    assert results[0].licenses == ["GPL-2.0"]
+
+
+def test_licenseref_tokens_stripped_from_unknown_spdx_and_expression():
+    scancode_file_list = [{
+        "path": "refs.py",
+        "type": "file",
+        "detected_license_expression": "unknown-spdx AND unknown-spdx",
+        "license_detections": [{
+            "matches": [{
+                "license_expression": "unknown-spdx AND unknown-spdx",
+                "matched_text": (
+                    "# SPDX-License-Identifier: LicenseRef-NEW AND LicenseRef-TEST"
+                ),
+            }],
+        }],
+        "copyrights": [],
+    }]
+
+    success, results, _messages, _ = parsing_scancode_32_later(scancode_file_list)
+
+    assert success is True
+    assert results[0].licenses == ["NEW", "TEST"]
+    assert results[0].comment == "NEW AND TEST"
+
+
+def test_legacy_unknown_spdx_uses_declared_identifier():
+    scancode_file_list = [{
+        "path": "example.sol",
+        "type": "file",
+        "licenses": [{
+            "key": "unknown-spdx",
+            "matched_text": "/* SPDX-License-Identifier: LicenseRef-MIT-like */",
+        }],
+        "copyrights": [],
+    }]
+
+    success, results, _messages, _ = parsing_scancode_32_earlier(scancode_file_list)
+
+    assert success is True
+    assert results[0].licenses == ["MIT-like"]
+
+
+def test_build_comment_from_detected_expression_helper():
+    matched_same = "# The code is not licensed under GPL-2.0."
+    matches = [
+        {
+            "license_expression": "unknown-spdx OR unknown-spdx",
+            "matched_text": "# SPDX-License-Identifier: NEW OR DApache-2.0",
+        },
+        {
+            "license_expression": "unknown-license-reference",
+            "matched_text": matched_same,
+        },
+        {
+            "license_expression": "gpl-2.0",
+            "matched_text": matched_same,
+        },
+    ]
+    other_texts = _matched_texts_with_other_licenses(matches)
+    comment = build_comment_from_detected_expression(
+        "(unknown-spdx OR unknown-spdx) AND unknown-license-reference AND gpl-2.0",
+        matches,
+        other_texts,
+    )
+    assert comment == "NEW OR DApache-2.0 AND GPL-2.0"

--- a/tests/test_parsing_unknown_spdx.py
+++ b/tests/test_parsing_unknown_spdx.py
@@ -264,3 +264,34 @@ def test_comment_with_parens_preserves_and_after_group():
         {matched_same},
     )
     assert comment == "MIT AND Apache-2.0"
+
+
+def test_two_license_comment_omits_outer_parentheses():
+    from fosslight_source._parsing_scancode_file_item import (
+        _omit_parens_for_two_license_expression,
+    )
+
+    assert _omit_parens_for_two_license_expression("(Apache-2.0 OR MIT)") == "Apache-2.0 OR MIT"
+    assert _omit_parens_for_two_license_expression("((Apache-2.0 OR MIT))") == "Apache-2.0 OR MIT"
+    # three licenses: keep grouping parentheses
+    assert (
+        _omit_parens_for_two_license_expression("GPL-2.0 AND (Apache-2.0 OR MIT)")
+        == "GPL-2.0 AND (Apache-2.0 OR MIT)"
+    )
+
+    scancode_file_list = [{
+        "path": "dual.txt",
+        "type": "file",
+        "detected_license_expression": "(unknown-spdx OR unknown-spdx)",
+        "license_detections": [{
+            "matches": [{
+                "license_expression": "unknown-spdx OR unknown-spdx",
+                "matched_text": "# SPDX-License-Identifier: Apache-2.0 OR MIT",
+            }],
+        }],
+        "copyrights": [],
+    }]
+    success, results, _messages, _ = parsing_scancode_32_later(scancode_file_list)
+    assert success is True
+    assert results[0].licenses == ["Apache-2.0", "MIT"]
+    assert results[0].comment == "Apache-2.0 OR MIT"

--- a/tests/test_parsing_unknown_spdx.py
+++ b/tests/test_parsing_unknown_spdx.py
@@ -216,3 +216,51 @@ def test_build_comment_from_detected_expression_helper():
         other_texts,
     )
     assert comment == "NEW OR DApache-2.0 AND GPL-2.0"
+
+
+def test_comment_without_parens_uses_operator_before_kept_token():
+    """A OR B AND C is (A OR B) AND C; removing B yields A AND C."""
+    matched_same = "not a license reference text"
+    matches = [
+        {"license_expression": "mit", "matched_text": "MIT"},
+        {"license_expression": "unknown-license-reference", "matched_text": matched_same},
+        {"license_expression": "apache-2.0", "matched_text": matched_same},
+    ]
+    comment = build_comment_from_detected_expression(
+        "mit OR unknown-license-reference AND apache-2.0",
+        matches,
+        {matched_same},
+    )
+    assert comment == "MIT AND Apache-2.0"
+
+
+def test_comment_with_parens_preserves_or_group():
+    """A OR (B AND C) removing B yields A OR C."""
+    matched_same = "not a license reference text"
+    matches = [
+        {"license_expression": "mit", "matched_text": "MIT"},
+        {"license_expression": "unknown-license-reference", "matched_text": matched_same},
+        {"license_expression": "apache-2.0", "matched_text": matched_same},
+    ]
+    comment = build_comment_from_detected_expression(
+        "mit OR (unknown-license-reference AND apache-2.0)",
+        matches,
+        {matched_same},
+    )
+    assert comment == "MIT OR Apache-2.0"
+
+
+def test_comment_with_parens_preserves_and_after_group():
+    """(A OR B) AND C removing B yields A AND C."""
+    matched_same = "not a license reference text"
+    matches = [
+        {"license_expression": "mit", "matched_text": "MIT"},
+        {"license_expression": "unknown-license-reference", "matched_text": matched_same},
+        {"license_expression": "apache-2.0", "matched_text": matched_same},
+    ]
+    comment = build_comment_from_detected_expression(
+        "(mit OR unknown-license-reference) AND apache-2.0",
+        matches,
+        {matched_same},
+    )
+    assert comment == "MIT AND Apache-2.0"

--- a/tests/test_parsing_unknown_spdx.py
+++ b/tests/test_parsing_unknown_spdx.py
@@ -173,7 +173,7 @@ def test_licenseref_tokens_stripped_from_unknown_spdx_and_expression():
 
     assert success is True
     assert results[0].licenses == ["NEW", "TEST"]
-    assert results[0].comment == "NEW AND TEST"
+    assert not results[0].comment
 
 
 def test_legacy_unknown_spdx_uses_declared_identifier():

--- a/tests/test_tox.py
+++ b/tests/test_tox.py
@@ -17,7 +17,8 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
 # Import after sys.path modification to access our custom GPL license functions
 # flake8: noqa E402
 from fosslight_source._parsing_scancode_file_item import (
-    is_gpl_family_license, should_remove_copyright_for_gpl_license_text
+    is_gpl_family_license, parsing_scancode_32_earlier, parsing_scancode_32_later,
+    should_remove_copyright_for_gpl_license_text
 )
 
 remove_directories = ["test_scan", "test_scan2", "test_scan3"]
@@ -135,6 +136,47 @@ def test_should_remove_copyright_for_gpl_license_text():
         "Should NOT remove copyright for empty license list"
     assert not should_remove_copyright_for_gpl_license_text([], False), \
         "Should NOT remove copyright for empty license list"
+
+
+@pytest.mark.parametrize(
+    ("declared_identifier", "expected_license"),
+    [
+        ("UNLICENSED", "UNLICENSED"),
+        ("LicenseRef-MIT-like", "MIT-like"),
+    ],
+)
+def test_unknown_spdx_uses_declared_identifier(declared_identifier, expected_license):
+    scancode_file_list = [{
+        "path": "example.sol",
+        "type": "file",
+        "license_detections": [{
+            "matches": [{
+                "license_expression": "unknown-spdx",
+                "matched_text": f"// SPDX-License-Identifier: {declared_identifier}",
+            }],
+        }],
+    }]
+
+    success, results, _messages, _license_list = parsing_scancode_32_later(scancode_file_list)
+
+    assert success is True
+    assert results[0].licenses == [expected_license]
+
+
+def test_legacy_unknown_spdx_uses_declared_identifier():
+    scancode_file_list = [{
+        "path": "example.sol",
+        "type": "file",
+        "licenses": [{
+            "key": "unknown-spdx",
+            "matched_text": "// SPDX-License-Identifier: LicenseRef-MIT-like",
+        }],
+    }]
+
+    success, results, _messages, _license_list = parsing_scancode_32_earlier(scancode_file_list)
+
+    assert success is True
+    assert results[0].licenses == ["MIT-like"]
 
 
 def test_run():

--- a/tests/test_tox.py
+++ b/tests/test_tox.py
@@ -17,8 +17,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
 # Import after sys.path modification to access our custom GPL license functions
 # flake8: noqa E402
 from fosslight_source._parsing_scancode_file_item import (
-    is_gpl_family_license, parsing_scancode_32_earlier, parsing_scancode_32_later,
-    should_remove_copyright_for_gpl_license_text
+    is_gpl_family_license, should_remove_copyright_for_gpl_license_text
 )
 
 remove_directories = ["test_scan", "test_scan2", "test_scan3"]
@@ -136,47 +135,6 @@ def test_should_remove_copyright_for_gpl_license_text():
         "Should NOT remove copyright for empty license list"
     assert not should_remove_copyright_for_gpl_license_text([], False), \
         "Should NOT remove copyright for empty license list"
-
-
-@pytest.mark.parametrize(
-    ("declared_identifier", "expected_license"),
-    [
-        ("UNLICENSED", "UNLICENSED"),
-        ("LicenseRef-MIT-like", "MIT-like"),
-    ],
-)
-def test_unknown_spdx_uses_declared_identifier(declared_identifier, expected_license):
-    scancode_file_list = [{
-        "path": "example.sol",
-        "type": "file",
-        "license_detections": [{
-            "matches": [{
-                "license_expression": "unknown-spdx",
-                "matched_text": f"// SPDX-License-Identifier: {declared_identifier}",
-            }],
-        }],
-    }]
-
-    success, results, _messages, _license_list = parsing_scancode_32_later(scancode_file_list)
-
-    assert success is True
-    assert results[0].licenses == [expected_license]
-
-
-def test_legacy_unknown_spdx_uses_declared_identifier():
-    scancode_file_list = [{
-        "path": "example.sol",
-        "type": "file",
-        "licenses": [{
-            "key": "unknown-spdx",
-            "matched_text": "// SPDX-License-Identifier: LicenseRef-MIT-like",
-        }],
-    }]
-
-    success, results, _messages, _license_list = parsing_scancode_32_earlier(scancode_file_list)
-
-    assert success is True
-    assert results[0].licenses == ["MIT-like"]
 
 
 def test_run():


### PR DESCRIPTION
## Summary

* **Bug Fixes**
  * Improved handling of unknown ScanCode license identifiers.
  * License references are now consistently extracted from SPDX license text.
  * SPDX validation now correctly rejects unsupported `LicenseRef-` prefixes, regardless of capitalization.
  - Preserves logical operators such as `AND` and `OR` in license expressions.
  - Reduces duplicate unknown-license results and reconstructs detected-license comments more accurately.

- **Tests**
  - Expanded coverage for mixed, unknown, and multi-license SPDX expressions across current and legacy scan formats.
  - Added validation for redundant reference suppression and expression formatting.