### PR TITLE
Keep non-FSF copyrights in GPL license text files

### DIFF
--- a/src/fosslight_source/_parsing_scancode_file_item.py
+++ b/src/fosslight_source/_parsing_scancode_file_item.py
@@ -60,6 +60,13 @@ def should_remove_copyright_for_gpl_license_text(licenses: list, is_license_text
     return is_license_text and is_gpl_family_license(licenses)
 
 
+def exclude_free_software_foundation_copyrights(copyrights: list) -> list:
+    return [
+        copyright_entry for copyright_entry in copyrights
+        if "free software foundation" not in copyright_entry.lower()
+    ]
+
+
 def _expression_has_non_unknown_license_reference(license_expression: str) -> bool:
     if not license_expression:
         return False
@@ -223,7 +230,9 @@ def parsing_scancode_32_earlier(
                         # Remove copyright info for license text file of GPL family
                         if should_remove_copyright_for_gpl_license_text(license_detected, result_item.is_license_text):
                             logger.debug(f"Removing copyright for GPL family license text file: {file_path}")
-                            result_item.copyright = []
+                            result_item.copyright = exclude_free_software_foundation_copyrights(
+                                copyright_value_list
+                            )
                         else:
                             result_item.copyright = copyright_value_list
 
@@ -718,7 +727,9 @@ def parsing_scancode_32_later(
                 # Remove copyright info for license text file of GPL family
                 if should_remove_copyright_for_gpl_license_text(license_detected, result_item.is_license_text):
                     logger.debug(f"Removing copyright for GPL family license text file: {file_path}")
-                    result_item.copyright = []
+                    result_item.copyright = exclude_free_software_foundation_copyrights(
+                        copyright_value_list
+                    )
                 else:
                     result_item.copyright = copyright_value_list
 

--- a/src/fosslight_source/_parsing_scancode_file_item.py
+++ b/src/fosslight_source/_parsing_scancode_file_item.py
@@ -29,7 +29,9 @@ KEYWORD_UNKNOWN_LICENSE_REFERENCE = "unknown-license-reference"
 SPDX_REPLACE_WORDS = ["(", ")"]
 KEY_AND_OR = re.compile(r"(?<=\s)(?:and|or)(?=\s)", re.IGNORECASE)
 KEY_AND_OR_CAPTURE = re.compile(r"(?<=\s)(and|or)(?=\s)", re.IGNORECASE)
-GPL_LICENSE_PATTERN = r'((a|l)?gpl|gfdl)'  # GPL, LGPL, AGPL, GFDL
+# GPL, LGPL, AGPL, GFDL
+GPL_LICENSE_PATTERN = re.compile(r'((a|l)?gpl|gfdl)', re.IGNORECASE)
+FSF_IN_COPYRIGHT = "free software foundation"
 SOURCE_EXTENSIONS = [
     '.java', '.cpp', '.c', '.cc', '.cxx', '.c++', '.h', '.hh', '.hpp', '.hxx', '.h++',
     '.cs', '.py', '.pyw', '.js', '.jsx', '.mjs', '.cjs', '.ts', '.tsx',
@@ -40,31 +42,15 @@ SOURCE_EXTENSIONS = [
 ]
 
 
-def is_gpl_family_license(licenses: list) -> bool:
-    if not licenses:
-        return False
-
-    for license_name in licenses:
-        if not license_name:
-            continue
-
-        license_lower = license_name.lower()
-        if re.search(GPL_LICENSE_PATTERN, license_lower):
-            logger.debug(f"GPL family license detected: {license_name}")
-            return True
-
-    return False
-
-
-def should_remove_copyright_for_gpl_license_text(licenses: list, is_license_text: bool) -> bool:
-    return is_license_text and is_gpl_family_license(licenses)
-
-
-def exclude_free_software_foundation_copyrights(copyrights: list) -> list:
-    return [
-        copyright_entry for copyright_entry in copyrights
-        if "free software foundation" not in copyright_entry.lower()
-    ]
+def filter_fsf_copyright_from_gpl_license_text(
+    copyrights: list, licenses: list, is_license_text: bool
+) -> list:
+    """Drop FSF boilerplate copyrights embedded in GPL-family license text."""
+    if not is_license_text or not any(
+        lic and GPL_LICENSE_PATTERN.search(lic) for lic in (licenses or [])
+    ):
+        return copyrights
+    return [c for c in copyrights if FSF_IN_COPYRIGHT not in c.lower()]
 
 
 def _expression_has_non_unknown_license_reference(license_expression: str) -> bool:
@@ -227,14 +213,9 @@ def parsing_scancode_32_earlier(
                     if len(license_detected) > 0:
                         result_item.licenses = license_detected
 
-                        # Remove copyright info for license text file of GPL family
-                        if should_remove_copyright_for_gpl_license_text(license_detected, result_item.is_license_text):
-                            logger.debug(f"Removing copyright for GPL family license text file: {file_path}")
-                            result_item.copyright = exclude_free_software_foundation_copyrights(
-                                copyright_value_list
-                            )
-                        else:
-                            result_item.copyright = copyright_value_list
+                        result_item.copyright = filter_fsf_copyright_from_gpl_license_text(
+                            copyright_value_list, license_detected, result_item.is_license_text
+                        )
 
                         if len(license_expression_list) > 0:
                             license_expression_list = list(
@@ -724,14 +705,9 @@ def parsing_scancode_32_later(
                     file.get("percentage_of_license_text", 0) > 90 and not is_source_file
                 )
 
-                # Remove copyright info for license text file of GPL family
-                if should_remove_copyright_for_gpl_license_text(license_detected, result_item.is_license_text):
-                    logger.debug(f"Removing copyright for GPL family license text file: {file_path}")
-                    result_item.copyright = exclude_free_software_foundation_copyrights(
-                        copyright_value_list
-                    )
-                else:
-                    result_item.copyright = copyright_value_list
+                result_item.copyright = filter_fsf_copyright_from_gpl_license_text(
+                    copyright_value_list, license_detected, result_item.is_license_text
+                )
 
                 if len(license_detected) > 1:
                     detected_expression = file.get("detected_license_expression", "") or ""

--- a/src/fosslight_source/_parsing_scancode_file_item.py
+++ b/src/fosslight_source/_parsing_scancode_file_item.py
@@ -208,7 +208,8 @@ def parsing_scancode_32_earlier(
                                         license_list[lic_matched_key] = lic_info
 
                         matched_rule = lic_item.get("matched_rule", {})
-                        result_item.is_license_text = matched_rule.get("is_license_text", False)
+                        if matched_rule.get("is_license_text", False):
+                            result_item.is_license_text = True
 
                     if len(license_detected) > 0:
                         result_item.licenses = license_detected

--- a/tests/test_parsing_unknown_spdx.py
+++ b/tests/test_parsing_unknown_spdx.py
@@ -193,6 +193,58 @@ def test_legacy_unknown_spdx_uses_declared_identifier():
     assert results[0].licenses == ["MIT-like"]
 
 
+@pytest.mark.parametrize(
+    "licenses",
+    [
+        # license-text first, then non-license-text: last-match overwrite used to keep FSF
+        [
+            {
+                "key": "gpl-3.0",
+                "spdx_license_key": "GPL-3.0-only",
+                "matched_rule": {"is_license_text": True},
+            },
+            {
+                "key": "mit",
+                "spdx_license_key": "MIT",
+                "matched_rule": {"is_license_text": False},
+            },
+        ],
+        # reverse order must also filter
+        [
+            {
+                "key": "mit",
+                "spdx_license_key": "MIT",
+                "matched_rule": {"is_license_text": False},
+            },
+            {
+                "key": "gpl-3.0",
+                "spdx_license_key": "GPL-3.0-only",
+                "matched_rule": {"is_license_text": True},
+            },
+        ],
+    ],
+)
+def test_legacy_aggregates_is_license_text_for_fsf_filter(licenses):
+    fsf = "Copyright (c) 2007 Free Software Foundation, Inc."
+    other = "Copyright (c) 2020 Example Inc."
+    scancode_file_list = [{
+        "path": "COPYING",
+        "type": "file",
+        "licenses": licenses,
+        "copyrights": [
+            {"copyright": fsf},
+            {"copyright": other},
+        ],
+    }]
+
+    success, results, _messages, _ = parsing_scancode_32_earlier(scancode_file_list)
+
+    assert success is True
+    assert results[0].is_license_text is True
+    assert fsf not in results[0].copyright
+    assert other in results[0].copyright
+
+
 def test_build_comment_from_detected_expression_helper():
     matched_same = "# The code is not licensed under GPL-2.0."
     matches = [

--- a/tests/test_tox.py
+++ b/tests/test_tox.py
@@ -17,7 +17,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
 # Import after sys.path modification to access our custom GPL license functions
 # flake8: noqa E402
 from fosslight_source._parsing_scancode_file_item import (
-    is_gpl_family_license, should_remove_copyright_for_gpl_license_text
+    filter_fsf_copyright_from_gpl_license_text,
 )
 
 remove_directories = ["test_scan", "test_scan2", "test_scan3"]
@@ -73,68 +73,19 @@ def run_command(command):
     return success, process.stdout if success else process.stderr
 
 
-def test_is_gpl_family_license():
-    gpl_licenses = [
-        ["gpl-2.0"],
-        ["gpl-3.0"],
-        ["lgpl-2.1"],
-        ["lgpl-3.0"],
-        ["agpl-3.0"],
-        ["GPL-2.0"],
-        ["LGPL-2.1"],
-        ["AGPL-3.0"],
-        ["gpl-2.0-only"],
-        ["lgpl-2.1-only"],
-        ["agpl-3.0-only"],
-        ["gfdl-1.3"],
-        ["gpl-2.0", "mit"],
-        ["mit", "lgpl-3.0"]
-    ]
+def test_filter_fsf_copyright_from_gpl_license_text():
+    fsf = "Copyright (c) 2007 Free Software Foundation, Inc."
+    other = "Copyright (c) 2020 LG Electronics Inc."
+    copyrights = [fsf, other]
 
-    non_gpl_licenses = [
-        ["mit"],
-        ["apache-2.0"],
-        ["bsd-3-clause"],
-        ["mozilla-2.0"],
-        ["isc"],
-        [],
-        ["mit", "apache-2.0"]
-    ]
+    # GPL-family license text: drop FSF boilerplate, keep others
+    for licenses in (["gpl-2.0"], ["lgpl-3.0"], ["agpl-3.0"], ["gfdl-1.3"], ["mit", "gpl-3.0"]):
+        assert filter_fsf_copyright_from_gpl_license_text(copyrights, licenses, True) == [other]
 
-    for licenses in gpl_licenses:
-        assert is_gpl_family_license(licenses), \
-            f"Should detect GPL family license: {licenses}"
-
-    for licenses in non_gpl_licenses:
-        assert not is_gpl_family_license(licenses), \
-            f"Should not detect GPL family license: {licenses}"
-
-
-def test_should_remove_copyright_for_gpl_license_text():
-    assert should_remove_copyright_for_gpl_license_text(["gpl-2.0"], True), \
-        "Should remove copyright for GPL license text file"
-    assert should_remove_copyright_for_gpl_license_text(["lgpl-3.0"], True), \
-        "Should remove copyright for LGPL license text file"
-    assert should_remove_copyright_for_gpl_license_text(["agpl-3.0"], True), \
-        "Should remove copyright for AGPL license text file"
-
-    assert not should_remove_copyright_for_gpl_license_text(["gpl-2.0"], False), \
-        "Should NOT remove copyright for GPL source file"
-    assert not should_remove_copyright_for_gpl_license_text(["lgpl-3.0"], False), \
-        "Should NOT remove copyright for LGPL source file"
-
-    assert not should_remove_copyright_for_gpl_license_text(["mit"], True), \
-        "Should NOT remove copyright for MIT license text file"
-    assert not should_remove_copyright_for_gpl_license_text(["apache-2.0"], True), \
-        "Should NOT remove copyright for Apache license text file"
-
-    assert not should_remove_copyright_for_gpl_license_text(["mit"], False), \
-        "Should NOT remove copyright for MIT source file"
-
-    assert not should_remove_copyright_for_gpl_license_text([], True), \
-        "Should NOT remove copyright for empty license list"
-    assert not should_remove_copyright_for_gpl_license_text([], False), \
-        "Should NOT remove copyright for empty license list"
+    # Non-GPL license text, or not license text: keep all
+    assert filter_fsf_copyright_from_gpl_license_text(copyrights, ["mit"], True) == copyrights
+    assert filter_fsf_copyright_from_gpl_license_text(copyrights, ["gpl-2.0"], False) == copyrights
+    assert filter_fsf_copyright_from_gpl_license_text(copyrights, [], True) == copyrights
 
 
 def test_run():


### PR DESCRIPTION
* **Bug Fixes**
  * Improved GPL license-text parsing by excluding only copyright entries associated with the Free Software Foundation.
  * Preserved other valid copyright information instead of removing all copyright entries.