### PR TITLE
Drop pre-32 ScanCode parsing path

### DIFF
--- a/src/fosslight_source/_license_matched.py
+++ b/src/fosslight_source/_license_matched.py
@@ -6,10 +6,8 @@ import logging
 import fosslight_util.constant as constant
 
 logger = logging.getLogger(constant.LOGGER_NAME)
-HEADER = ['No', 'Category', 'License',
-          'Matched Text', 'File Count', 'Files']
-HEADER_32_LATER = ['No', 'License', 'Matched Text',
-                   'File Count', 'Files']
+HEADER = ['No', 'License', 'Matched Text',
+          'File Count', 'Files']
 LOW_PRIORITY = ['Permissive', 'Public Domain']
 
 
@@ -46,18 +44,15 @@ class MatchedLicense:
     def set_matched_text(self, value: str) -> None:
         self.matched_text = value
 
-    def get_row_to_print(self, result_for_32_earlier: bool = True) -> list:
-        if result_for_32_earlier:
-            print_rows = [self.category, self.license, self.matched_text, str(len(self.files)), ','.join(self.files)]
-        else:
-            print_rows = [self.license, self.matched_text, str(len(self.files)), ','.join(self.files)]
-        return print_rows
+    def get_row_to_print(self) -> list:
+        return [self.license, self.matched_text, str(len(self.files)), ','.join(self.files)]
 
 
 def get_license_list_to_print(license_list: dict) -> list:
-    result_for_32_earlier = any([value.category for key, value in license_list.items()])
-    license_items = license_list.values()
-    license_items = sorted(license_items, key=lambda row: (row.priority, row.category, row.license))
-    license_rows = [lic_item.get_row_to_print(result_for_32_earlier) for lic_item in license_items]
-    license_rows.insert(0, HEADER if result_for_32_earlier else HEADER_32_LATER)
+    license_items = sorted(
+        license_list.values(),
+        key=lambda row: (row.priority, row.category, row.license),
+    )
+    license_rows = [lic_item.get_row_to_print() for lic_item in license_items]
+    license_rows.insert(0, HEADER)
     return license_rows

--- a/src/fosslight_source/_parsing_scancode_file_item.py
+++ b/src/fosslight_source/_parsing_scancode_file_item.py
@@ -93,147 +93,6 @@ def get_error_from_header(header_item: list) -> Tuple[bool, str]:
     return has_error, str_error
 
 
-def parsing_scancode_32_earlier(
-    scancode_file_list: list, has_error: bool = False, ui_mode: bool = False
-) -> Tuple[bool, list, list, dict]:
-    rc = True
-    msg = []
-    scancode_file_item = []
-    license_list = {}  # Key :[license]+[matched_text], value: MatchedLicense()
-
-    if scancode_file_list:
-        for file in scancode_file_list:
-            try:
-                is_dir = False
-                file_path = file.get("path", "")
-                if not file_path:
-                    continue
-                is_binary = file.get("is_binary", False)
-                if "type" in file:
-                    is_dir = file["type"] == "directory"
-                if not is_binary and not is_dir:
-                    licenses = file.get("licenses", [])
-                    copyright_list = file.get("copyrights", [])
-
-                    result_item = SourceItem(file_path)
-
-                    if has_error and "scan_errors" in file:
-                        error_msg = file.get("scan_errors", [])
-                        if len(error_msg) > 0:
-                            result_item.comment = ",".join(error_msg)
-                            scancode_file_item.append(result_item)
-                            continue
-                    copyright_value_list = []
-                    for x in copyright_list:
-                        latest_key_data = x.get("copyright", "")
-                        if latest_key_data:
-                            copyright_data = latest_key_data
-                        else:
-                            copyright_data = x.get("value", "")
-                        if copyright_data:
-                            try:
-                                copyright_data = re.sub(KEYWORD_SPDX_ID, '', copyright_data, flags=re.I)
-                                copyright_data = re.sub(KEYWORD_DOWNLOAD_LOC, '', copyright_data, flags=re.I).strip()
-                            except Exception:
-                                pass
-                            copyright_value_list.append(copyright_data)
-
-                    # Set the license value
-                    license_detected = []
-                    if not licenses:
-                        licenses = []
-                    # Keep license and/or copyright findings; UI keeps finding-less files too.
-                    if not licenses and not copyright_value_list and not ui_mode:
-                        continue
-
-                    license_expression_list = file.get("license_expressions", {})
-                    if len(license_expression_list) > 0:
-                        license_expression_list = [
-                            x.lower() for x in license_expression_list
-                            if x is not None]
-
-                    matched_texts_with_other_licenses = {
-                        (lic_item.get("matched_text") or "")
-                        for lic_item in licenses
-                        if (lic_item.get("matched_text") or "")
-                        and (lic_item.get("key") or "")
-                        and KEYWORD_UNKNOWN_LICENSE_REFERENCE not in (lic_item.get("key") or "").lower()
-                    }
-
-                    for lic_item in licenses:
-                        license_value = ""
-                        key = lic_item.get("key", "")
-                        if key in REMOVE_LICENSE:
-                            if key in license_expression_list:
-                                license_expression_list.remove(key)
-                            continue
-                        spdx = lic_item.get("spdx_license_key", "")
-                        # logger.debug("LICENSE_KEY:"+str(key)+",SPDX:"+str(spdx))
-
-                        if key is not None and key != "":
-                            key = key.lower()
-                            license_value = key
-                            if key in license_expression_list:
-                                license_expression_list.remove(key)
-                        if spdx is not None and spdx != "":
-                            # Print SPDX instead of Key.
-                            license_value = spdx.lower()
-
-                        if license_value != "":
-                            matched_txt = lic_item.get("matched_text", "")
-                            if (
-                                KEYWORD_UNKNOWN_LICENSE_REFERENCE in (key or "")
-                                and matched_txt in matched_texts_with_other_licenses
-                            ):
-                                continue
-                            if KEYWORD_SCANCODE_UNKNOWN in (key or ""):
-                                declared = _extract_spdx_declared_expression(matched_txt)
-                                if declared:
-                                    license_value = declared
-
-                            for word in replace_word:
-                                if word in license_value:
-                                    license_value = license_value.replace(word, "")
-                            license_detected.append(license_value)
-
-                            # Add matched licenses
-                            if "category" in lic_item:
-                                lic_category = lic_item["category"]
-                                if matched_txt:
-                                    lic_matched_key = license_value + matched_txt
-                                    if lic_matched_key in license_list:
-                                        license_list[lic_matched_key].set_files(file_path)
-                                    else:
-                                        lic_info = MatchedLicense(license_value, lic_category, matched_txt, file_path)
-                                        license_list[lic_matched_key] = lic_info
-
-                        matched_rule = lic_item.get("matched_rule", {})
-                        if matched_rule.get("is_license_text", False):
-                            result_item.is_license_text = True
-
-                    if len(license_detected) > 0:
-                        result_item.licenses = license_detected
-
-                        result_item.copyright = filter_fsf_copyright_from_gpl_license_text(
-                            copyright_value_list, license_detected, result_item.is_license_text
-                        )
-
-                        if len(license_expression_list) > 0:
-                            license_expression_list = list(
-                                set(license_expression_list))
-                            result_item.comment = ','.join(license_expression_list)
-
-                        scancode_file_item.append(result_item)
-                    elif copyright_value_list or ui_mode:
-                        result_item.copyright = copyright_value_list
-                        scancode_file_item.append(result_item)
-            except Exception as ex:
-                msg.append(f"Error Parsing item: {ex}")
-                rc = False
-    msg = list(set(msg))
-    return rc, scancode_file_item, msg, license_list
-
-
 def split_spdx_expression(spdx_string: str) -> list:
     for replace in SPDX_REPLACE_WORDS:
         spdx_string = spdx_string.replace(replace, "")
@@ -746,19 +605,10 @@ def parsing_file_item(
     scancode_file_list: list, has_error: bool, need_matched_license: bool = False,
     ui_mode: bool = False
 ) -> Tuple[bool, list, list, dict]:
-
-    rc = True
-    msg = []
-
-    first_item = next(iter(scancode_file_list or []), {})
-    if "licenses" in first_item:
-        rc, scancode_file_item, msg, license_list = parsing_scancode_32_earlier(
-            scancode_file_list, has_error, ui_mode
-        )
-    else:
-        rc, scancode_file_item, msg, license_list = parsing_scancode_32_later(
-            scancode_file_list, has_error, ui_mode
-        )
+    # scancode-toolkit>=32.0.2 always uses license_detections schema
+    rc, scancode_file_item, msg, license_list = parsing_scancode_32_later(
+        scancode_file_list, has_error, ui_mode
+    )
     if not need_matched_license:
         license_list = {}
     return rc, scancode_file_item, msg, license_list

--- a/src/fosslight_source/_parsing_scancode_file_item.py
+++ b/src/fosslight_source/_parsing_scancode_file_item.py
@@ -475,7 +475,7 @@ def get_license_expression_spdx(license_expression: str) -> str:
         return ""
 
 
-def parsing_scancode_32_later(
+def parsing_scancode(
     scancode_file_list: list, has_error: bool = False, ui_mode: bool = False
 ) -> Tuple[bool, list, list, dict]:
     rc = True
@@ -606,7 +606,7 @@ def parsing_file_item(
     ui_mode: bool = False
 ) -> Tuple[bool, list, list, dict]:
     # scancode-toolkit>=32.0.2 always uses license_detections schema
-    rc, scancode_file_item, msg, license_list = parsing_scancode_32_later(
+    rc, scancode_file_item, msg, license_list = parsing_scancode(
         scancode_file_list, has_error, ui_mode
     )
     if not need_matched_license:

--- a/tests/test_parsing_unknown_spdx.py
+++ b/tests/test_parsing_unknown_spdx.py
@@ -8,7 +8,7 @@ from fosslight_source._parsing_scancode_file_item import (
     _extract_spdx_declared_expression,
     _declared_licenses_from_matched_text,
     build_comment_from_detected_expression,
-    parsing_scancode_32_later,
+    parsing_scancode,
     _matched_texts_with_other_licenses,
 )
 
@@ -64,7 +64,7 @@ def test_unknown_spdx_uses_declared_identifier(matched_text, expected_license):
         "copyrights": [],
     }]
 
-    success, results, _messages, _license_list = parsing_scancode_32_later(scancode_file_list)
+    success, results, _messages, _license_list = parsing_scancode(scancode_file_list)
 
     assert success is True
     assert results[0].licenses == [expected_license]
@@ -84,7 +84,7 @@ def test_unknown_spdx_in_compound_expression_splits_and_or():
         "copyrights": [],
     }]
 
-    success, results, _messages, _ = parsing_scancode_32_later(scancode_file_list)
+    success, results, _messages, _ = parsing_scancode(scancode_file_list)
 
     assert success is True
     assert results[0].licenses == ["GPL-2.0", "MIT-like"]
@@ -118,7 +118,7 @@ def test_unknown_spdx_comment_preserves_and_or_from_detected_expression():
         "copyrights": [],
     }]
 
-    success, results, _messages, _ = parsing_scancode_32_later(scancode_file_list)
+    success, results, _messages, _ = parsing_scancode(scancode_file_list)
 
     assert success is True
     assert results[0].licenses == ["NEW", "DApache-2.0", "GPL-2.0"]
@@ -146,7 +146,7 @@ def test_unknown_license_reference_suppressed_when_same_matched_text_has_other_l
         "copyrights": [],
     }]
 
-    success, results, _messages, _ = parsing_scancode_32_later(scancode_file_list)
+    success, results, _messages, _ = parsing_scancode(scancode_file_list)
 
     assert success is True
     assert results[0].licenses == ["GPL-2.0"]
@@ -168,7 +168,7 @@ def test_licenseref_tokens_stripped_from_unknown_spdx_and_expression():
         "copyrights": [],
     }]
 
-    success, results, _messages, _ = parsing_scancode_32_later(scancode_file_list)
+    success, results, _messages, _ = parsing_scancode(scancode_file_list)
 
     assert success is True
     assert results[0].licenses == ["NEW", "TEST"]
@@ -273,7 +273,7 @@ def test_two_license_comment_omits_outer_parentheses():
         }],
         "copyrights": [],
     }]
-    success, results, _messages, _ = parsing_scancode_32_later(scancode_file_list)
+    success, results, _messages, _ = parsing_scancode(scancode_file_list)
     assert success is True
     assert results[0].licenses == ["Apache-2.0", "MIT"]
     assert results[0].comment == "Apache-2.0 OR MIT"

--- a/tests/test_parsing_unknown_spdx.py
+++ b/tests/test_parsing_unknown_spdx.py
@@ -8,7 +8,6 @@ from fosslight_source._parsing_scancode_file_item import (
     _extract_spdx_declared_expression,
     _declared_licenses_from_matched_text,
     build_comment_from_detected_expression,
-    parsing_scancode_32_earlier,
     parsing_scancode_32_later,
     _matched_texts_with_other_licenses,
 )
@@ -174,75 +173,6 @@ def test_licenseref_tokens_stripped_from_unknown_spdx_and_expression():
     assert success is True
     assert results[0].licenses == ["NEW", "TEST"]
     assert not results[0].comment
-
-
-def test_legacy_unknown_spdx_uses_declared_identifier():
-    scancode_file_list = [{
-        "path": "example.sol",
-        "type": "file",
-        "licenses": [{
-            "key": "unknown-spdx",
-            "matched_text": "/* SPDX-License-Identifier: LicenseRef-MIT-like */",
-        }],
-        "copyrights": [],
-    }]
-
-    success, results, _messages, _ = parsing_scancode_32_earlier(scancode_file_list)
-
-    assert success is True
-    assert results[0].licenses == ["MIT-like"]
-
-
-@pytest.mark.parametrize(
-    "licenses",
-    [
-        # license-text first, then non-license-text: last-match overwrite used to keep FSF
-        [
-            {
-                "key": "gpl-3.0",
-                "spdx_license_key": "GPL-3.0-only",
-                "matched_rule": {"is_license_text": True},
-            },
-            {
-                "key": "mit",
-                "spdx_license_key": "MIT",
-                "matched_rule": {"is_license_text": False},
-            },
-        ],
-        # reverse order must also filter
-        [
-            {
-                "key": "mit",
-                "spdx_license_key": "MIT",
-                "matched_rule": {"is_license_text": False},
-            },
-            {
-                "key": "gpl-3.0",
-                "spdx_license_key": "GPL-3.0-only",
-                "matched_rule": {"is_license_text": True},
-            },
-        ],
-    ],
-)
-def test_legacy_aggregates_is_license_text_for_fsf_filter(licenses):
-    fsf = "Copyright (c) 2007 Free Software Foundation, Inc."
-    other = "Copyright (c) 2020 Example Inc."
-    scancode_file_list = [{
-        "path": "COPYING",
-        "type": "file",
-        "licenses": licenses,
-        "copyrights": [
-            {"copyright": fsf},
-            {"copyright": other},
-        ],
-    }]
-
-    success, results, _messages, _ = parsing_scancode_32_earlier(scancode_file_list)
-
-    assert success is True
-    assert results[0].is_license_text is True
-    assert fsf not in results[0].copyright
-    assert other in results[0].copyright
 
 
 def test_build_comment_from_detected_expression_helper():

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 [tox]
 envlist = test_run
-skipdist = true
 
 [testenv]
 install_command = pip install {opts} {packages}


### PR DESCRIPTION
# Require scancode-toolkit>=32.0.2 license_detections only, and simplify matched-text sheet output without the legacy Category column.
- **Improvements**
  - License reports now use a simplified format without the category column.
  - License entries are presented in a consistent priority and license order.
  - ScanCode results are processed through a unified parsing flow.
  - Improved handling of unknown SPDX identifiers, compound expressions, suppressed findings, custom license references, and parenthesized expressions.