### PR TITLE
fix(scanoss): minimum version >=1.45.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,9 +27,9 @@ requires-python = ">=3.10,<3.15"
 dependencies = [
     "setuptools<=80.10.2",
     "pyparsing",
-    "scanoss>=1.19.0",
+    "scanoss>=1.45.0",
     "XlsxWriter",
-    "fosslight_util>=2.2.2",
+    "fosslight_util>=2.2.7",
     "PyYAML",
     "wheel>=0.38.1",
     "intbitset",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,6 +3,6 @@ pytest
 pytest-cov
 flake8
 dataclasses
-scanoss
+scanoss>=1.45.0
 importlib-metadata
 pytest-xdist


### PR DESCRIPTION
  * Updated the SCANOSS integration requirement to version 1.45.0 or newer.
  * Aligned development dependencies with the same minimum version requirement.