### PR TITLE
Change logging level of SPDX extraction failures

### DIFF
--- a/src/fosslight_source/run_spdx_extractor.py
+++ b/src/fosslight_source/run_spdx_extractor.py
@@ -22,5 +22,5 @@ def get_spdx_downloads(file_path: str) -> list[str]:
                     for word in find_word.findall(mmap_obj):
                         results.append(word.decode('utf-8'))
     except Exception as ex:
-        logger.warning(f"Failed to extract SPDX download location. {file_path}, {ex}")
+        logger.debug(f"Failed to extract SPDX download location. {file_path}, {ex}")
     return results


### PR DESCRIPTION
  * Reduced the visibility of a non-critical diagnostic message without changing application behavior.