### PR TITLE
Filter excluded filenames after ScanCode instead of --ignore

### DIFF
--- a/.github/release-drafter-config.yml
+++ b/.github/release-drafter-config.yml
@@ -3,6 +3,8 @@ tag-template: 'v$RESOLVED_VERSION'
 categories:
   - title: '🚀 Features'
     label: 'enhancement'
+  - title: '✨ Improvements'
+    label: 'improvement'
   - title: '🐛 Hotfixes'
     labels:
       - 'bug'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "pyparsing",
     "scanoss>=1.45.0",
     "XlsxWriter",
-    "fosslight_util>=2.2.7",
+    "fosslight_util>=2.2.8",
     "PyYAML",
     "wheel>=0.38.1",
     "intbitset",

--- a/src/fosslight_source/_parsing_scancode_file_item.py
+++ b/src/fosslight_source/_parsing_scancode_file_item.py
@@ -7,6 +7,7 @@ import os
 import logging
 import re
 import fosslight_util.constant as constant
+from fosslight_util.exclude import is_excluded_filename
 from ._license_matched import MatchedLicense
 from ._scan_item import SourceItem
 from ._scan_item import replace_word
@@ -492,6 +493,9 @@ def parsing_scancode(
                 is_dir = file.get("type", "") == "directory"
                 if (not file_path) or is_binary or is_dir:
                     logger.info(f"Skipping {file_path} because it is binary or directory")
+                    continue
+                if is_excluded_filename(file_path):
+                    logger.debug(f"Skipping {file_path} because it is an excluded filename")
                     continue
                 result_item = SourceItem(file_path)
                 if has_error:

--- a/src/fosslight_source/cli.py
+++ b/src/fosslight_source/cli.py
@@ -29,13 +29,12 @@ import tqdm
 import argparse
 from .run_spdx_extractor import get_spdx_downloads
 from .run_manifest_extractor import get_manifest_licenses
-from ._scan_item import SourceItem, resolve_kb_config, is_notice_file
+from ._scan_item import SourceItem, resolve_kb_config, is_notice_file, is_manifest_file
 from ._kb_client import fetch_origin_urls_via_scan_job
 from fosslight_util.cover import dump_result_log
 from fosslight_util.time import current_timestamp_utc, format_running_time, timestamp_for_filename
 from fosslight_util.oss_item import ScannerItem
 from typing import Optional, Tuple
-from ._scan_item import is_manifest_file
 import shutil
 from ._merge import (
     _add_pre_merge_sheet,

--- a/src/fosslight_source/run_scancode.py
+++ b/src/fosslight_source/run_scancode.py
@@ -19,7 +19,6 @@ from fosslight_util.output_format import check_output_formats_v2
 from fosslight_util.exclude import (
     EXCLUDE_DIRECTORY,
     EXCLUDE_FILE_EXTENSION,
-    EXCLUDE_FILENAME,
     PACKAGE_DIRECTORY,
 )
 
@@ -166,14 +165,14 @@ def _default_scancode_ignore_patterns(
     Directory names use path-based globs (e.g. **/tests/**) so they do not match
     the scan root directory name itself.
     Binary files are excluded separately via scancode --ignore-binaries.
+    EXCLUDE_FILENAME is not passed to ScanCode --ignore: matching many exact
+    names on a large tree is slow. Those files are dropped after parsing.
     """
     patterns = {".*"}
     for name in PACKAGE_DIRECTORY + EXCLUDE_DIRECTORY:
         patterns.add(_directory_ignore_pattern(name))
     for ext in EXCLUDE_FILE_EXTENSION:
         patterns.add(f"*.{ext}")
-    for name in EXCLUDE_FILENAME:
-        patterns.add(name)
 
     for pattern in path_to_exclude or []:
         if os.path.isabs(pattern):


### PR DESCRIPTION
Keep directory and extension ignores in ScanCode, but drop EXCLUDE_FILENAME matches at parse time so large trees are not slowed by exact-name ignore matching.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Excluded filenames are now consistently omitted from parsed source results.
  * Scan results no longer include files that should be excluded.

* **Chores**
  * Updated the minimum supported utility package version.
  * Improved release categorization for enhancements and improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->