### PR TITLE
Use os trust store for https kb

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ dependencies = [
     "psycopg2-binary>=2.9.10; python_version >= '3.13'",
     "tomli; python_version < '3.11'",
     "tqdm",
+    "truststore",
 ]
 
 [project.optional-dependencies]

--- a/src/fosslight_source/_help.py
+++ b/src/fosslight_source/_help.py
@@ -45,6 +45,8 @@ _HELP_MESSAGE_SOURCE_SCANNER = f"""
     --hide_progress        Hide the progress bar during scanning
     --kb_url <url>         KB API URL (priority: parameter > KB_URL env > default)
     --kb_token <token>     KB bearer token (priority: parameter > KB_TOKEN env)
+                           HTTPS uses the OS certificate store. Set KB_SSL_VERIFY=false
+                           only if certificate verification must be skipped.
 
     💡 Examples
     ────────────────────────────────────────────────────────────────────

--- a/src/fosslight_source/_kb_client.py
+++ b/src/fosslight_source/_kb_client.py
@@ -5,6 +5,8 @@
 
 import json
 import logging
+import os
+import ssl
 import time
 import urllib.error
 import urllib.request
@@ -19,6 +21,31 @@ _SCAN_JOB_POLL_MAX_INTERVAL_SEC = 10.0
 _SCAN_JOB_REQUEST_TIMEOUT_SEC = 30
 _SCAN_JOB_MIN_WAIT_SEC = 300
 _SCAN_JOB_PER_HASH_SEC = 35
+_KB_SSL_VERIFY_FALSE = {"0", "false", "no", "off"}
+_logged_insecure_kb_ssl = False
+
+
+def kb_ssl_verify_enabled() -> bool:
+    raw = os.environ.get("KB_SSL_VERIFY", "true")
+    return raw.strip().lower() not in _KB_SSL_VERIFY_FALSE
+
+
+def create_kb_ssl_context() -> ssl.SSLContext:
+    """TLS context for KB HTTPS. Uses the OS trust store (Windows store, like the browser)."""
+    global _logged_insecure_kb_ssl
+    if not kb_ssl_verify_enabled():
+        if not _logged_insecure_kb_ssl:
+            logger.warning("KB TLS certificate verification is disabled (KB_SSL_VERIFY)")
+            _logged_insecure_kb_ssl = True
+        ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+        ctx.check_hostname = False
+        ctx.verify_mode = ssl.CERT_NONE
+        return ctx
+    try:
+        import truststore
+        return truststore.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+    except ImportError:
+        return ssl.create_default_context()
 
 
 def _kb_request(
@@ -40,7 +67,7 @@ def _kb_request(
     if kb_token:
         request.add_header("Authorization", f"Bearer {kb_token}")
 
-    with urllib.request.urlopen(request, timeout=timeout) as response:
+    with urllib.request.urlopen(request, timeout=timeout, context=create_kb_ssl_context()) as response:
         body = response.read().decode()
         return json.loads(body) if body else {}
 

--- a/src/fosslight_source/cli.py
+++ b/src/fosslight_source/cli.py
@@ -30,7 +30,7 @@ import argparse
 from .run_spdx_extractor import get_spdx_downloads
 from .run_manifest_extractor import get_manifest_licenses
 from ._scan_item import SourceItem, resolve_kb_config, is_notice_file, is_manifest_file
-from ._kb_client import fetch_origin_urls_via_scan_job
+from ._kb_client import create_kb_ssl_context, fetch_origin_urls_via_scan_job
 from fosslight_util.cover import dump_result_log
 from fosslight_util.time import current_timestamp_utc, format_running_time, timestamp_for_filename
 from fosslight_util.oss_item import ScannerItem
@@ -295,7 +295,7 @@ def check_kb_server_reachable(kb_url: str, kb_token: str = "") -> bool:
             request = urllib.request.Request(f"{kb_url}health", method='GET')
             if kb_token:
                 request.add_header('Authorization', f'Bearer {kb_token}')
-            with urllib.request.urlopen(request, timeout=10) as response:
+            with urllib.request.urlopen(request, timeout=10, context=create_kb_ssl_context()) as response:
                 logger.debug(f"KB server is reachable. Response status: {response.status}")
                 return True
         except urllib.error.HTTPError:

--- a/tests/test_kb_ssl.py
+++ b/tests/test_kb_ssl.py
@@ -1,0 +1,52 @@
+# Copyright (c) 2026 LG Electronics Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for KB HTTPS SSL context selection."""
+
+import ssl
+from unittest.mock import patch
+
+from fosslight_source._kb_client import create_kb_ssl_context, kb_ssl_verify_enabled
+
+
+def test_kb_ssl_verify_enabled_default(monkeypatch):
+    monkeypatch.delenv("KB_SSL_VERIFY", raising=False)
+    assert kb_ssl_verify_enabled() is True
+
+
+def test_kb_ssl_verify_disabled_values(monkeypatch):
+    for value in ("false", "0", "no", "OFF"):
+        monkeypatch.setenv("KB_SSL_VERIFY", value)
+        assert kb_ssl_verify_enabled() is False
+
+
+def test_create_kb_ssl_context_insecure(monkeypatch):
+    monkeypatch.setenv("KB_SSL_VERIFY", "false")
+    ctx = create_kb_ssl_context()
+    assert ctx.verify_mode == ssl.CERT_NONE
+    assert ctx.check_hostname is False
+
+
+def test_create_kb_ssl_context_uses_truststore_when_verify_on(monkeypatch):
+    monkeypatch.setenv("KB_SSL_VERIFY", "true")
+    ctx = create_kb_ssl_context()
+    assert ctx.verify_mode != ssl.CERT_NONE
+    assert ctx.check_hostname is True
+
+
+def test_kb_request_passes_ssl_context():
+    from fosslight_source._kb_client import _kb_request
+
+    class _Resp:
+        def read(self):
+            return b"{}"
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+    with patch("fosslight_source._kb_client.urllib.request.urlopen", return_value=_Resp()) as urlopen:
+        _kb_request("https://kb.example/", "health")
+        assert urlopen.call_args.kwargs["context"] is not None
+        assert isinstance(urlopen.call_args.kwargs["context"], ssl.SSLContext)


### PR DESCRIPTION
Python urllib failed on Windows with CERTIFICATE_VERIFY_FAILED while the browser succeeded. Verify KB HTTPS against the OS certificate store and allow KB_SSL_VERIFY=false as an escape hatch.

