### PR TITLE
Detect binaries in parallel during pre-scan

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "pyparsing",
     "scanoss>=1.45.0",
     "XlsxWriter",
-    "fosslight_util>=2.2.8",
+    "fosslight_util>=2.2.11",
     "PyYAML",
     "wheel>=0.38.1",
     "intbitset",

--- a/src/fosslight_source/_merge.py
+++ b/src/fosslight_source/_merge.py
@@ -111,7 +111,8 @@ def _get_top_merge_values(scan_items: list, value_getter) -> list:
             normalized_value = _normalize_merge_text(value)
             if normalized_value:
                 values.append(normalized_value)
-    return [value for value, _ in Counter(values).most_common(3)]
+    ranked = sorted(Counter(values).items(), key=lambda entry: (-entry[1], entry[0]))
+    return [value for value, _ in ranked[:3]]
 
 
 def _can_merge_folder(scan_items: list) -> bool:

--- a/src/fosslight_source/_parsing_scancode_file_item.py
+++ b/src/fosslight_source/_parsing_scancode_file_item.py
@@ -605,8 +605,10 @@ def parsing_scancode(
                     file.get("percentage_of_license_text", 0) > 90 and not is_source_file
                 )
 
-                result_item.copyright = filter_fsf_copyright_from_gpl_license_text(
-                    copyright_value_list, license_detected, result_item.is_license_text
+                result_item.copyright = sorted(
+                    filter_fsf_copyright_from_gpl_license_text(
+                        copyright_value_list, license_detected, result_item.is_license_text
+                    )
                 )
 
                 if len(license_detected) > 1:

--- a/src/fosslight_source/_parsing_scancode_file_item.py
+++ b/src/fosslight_source/_parsing_scancode_file_item.py
@@ -6,6 +6,7 @@
 import os
 import logging
 import re
+from functools import lru_cache
 import fosslight_util.constant as constant
 from fosslight_util.exclude import is_excluded_filename
 from ._license_matched import MatchedLicense
@@ -484,12 +485,24 @@ def build_comment_from_detected_expression(
     )
 
 
+@lru_cache(maxsize=65536)
 def get_license_expression_spdx(license_expression: str) -> str:
     if not license_expression or not license_expression.strip():
         return ""
     try:
-        from licensedcode.cache import build_spdx_license_expression
-        result = build_spdx_license_expression(license_expression.strip())
+        from licensedcode.cache import (
+            build_spdx_license_expression,
+            get_licenses_db,
+            get_licensing,
+        )
+        expression = license_expression.strip()
+        # licensedcode re-reads the whole license database from disk for every
+        # key it cannot resolve, and then raises anyway. Screen the keys first
+        # so unknown tokens stay cheap.
+        licenses_db = get_licenses_db()
+        if any(key not in licenses_db for key in get_licensing().license_keys(expression)):
+            return ""
+        result = build_spdx_license_expression(expression)
         if result is None:
             return ""
         if isinstance(result, str) and result.lower().startswith("licenseref-"):

--- a/src/fosslight_source/_scan_item.py
+++ b/src/fosslight_source/_scan_item.py
@@ -7,6 +7,7 @@ import os
 import logging
 import re
 import hashlib
+from bisect import insort
 import fosslight_util.constant as constant
 from fosslight_util.oss_item import FileItem, OssItem, get_checksum_sha1
 
@@ -78,13 +79,13 @@ class SourceItem(FileItem):
     def licenses(self, value: list) -> None:
         if value:
             max_length_exceed = False
-            for new_lic in value:
+            for new_lic in sorted(value):
                 if new_lic:
                     if len(new_lic) > MAX_LICENSE_LENGTH:
                         new_lic = new_lic[:MAX_LICENSE_LENGTH]
                         max_length_exceed = True
                     if new_lic not in self._licenses:
-                        self._licenses.append(new_lic)
+                        insort(self._licenses, new_lic)
                         if len(",".join(self._licenses)) > MAX_LICENSE_TOTAL_LENGTH:
                             self._licenses.remove(new_lic)
                             max_length_exceed = True
@@ -180,10 +181,11 @@ class SourceItem(FileItem):
         kb_origin_urls: dict[str, str] | None = None,
     ) -> None:
         self.oss_items = []
+        copyrights = "\n".join(self.copyright)
         if self.download_location:
             for url in self.download_location:
                 item = OssItem(self.oss_name, self.oss_version, self.licenses, url)
-                item.copyright = "\n".join(self.copyright)
+                item.copyright = copyrights
                 item.comment = self.comment
                 self.oss_items.append(item)
         else:
@@ -198,7 +200,7 @@ class SourceItem(FileItem):
                         oss_name, oss_version, download_url = self._apply_kb_origin_url(origin_url)
                         item = OssItem(oss_name, oss_version, self.licenses, download_url)
 
-            item.copyright = "\n".join(self.copyright)
+            item.copyright = copyrights
             item.comment = self.comment
             self.oss_items.append(item)
 

--- a/src/fosslight_source/_scancode_ignore_binaries.py
+++ b/src/fosslight_source/_scancode_ignore_binaries.py
@@ -6,11 +6,21 @@
 # so PyPI installs do not need a GitHub git dependency.
 # SPDX-PackageDownloadLocation: https://github.com/aboutcode-org/scancode-plugins/tree/main/misc/scancode-ignore-binaries
 
+import logging
+import multiprocessing
+
 from plugincode.pre_scan import PreScanPlugin
 from plugincode.pre_scan import pre_scan_impl
 from commoncode.cliutils import PluggableCommandLineOption
 from commoncode.cliutils import PRE_SCAN_GROUP
 from typecode.contenttype import get_type
+
+logger = logging.getLogger(__name__)
+
+# Detection costs one get_type() call per file, which reads from disk. On large
+# trees that dominates the pre-scan stage, so spread it over the scan processes.
+PARALLEL_MIN_FILES = 2000
+CHUNK_SIZE = 256
 
 
 @pre_scan_impl
@@ -32,22 +42,47 @@ class IgnoreBinaries(PreScanPlugin):
     def is_enabled(self, ignore_binaries, **kwargs):
         return ignore_binaries
 
-    def process_codebase(self, codebase, ignore_binaries, **kwargs):
+    def process_codebase(self, codebase, ignore_binaries, processes=1, **kwargs):
         """
         Remove binary Resources from the resource tree.
         """
         if not ignore_binaries:
             return
 
-        resources_to_remove = []
-        for resource in codebase.walk():
-            if not resource.is_file:
-                continue
-            if is_binary(resource.location):
-                resources_to_remove.append(resource)
+        # Collect first: removing while walking would invalidate the walk.
+        candidates = [
+            (resource.path, resource.location)
+            for resource in codebase.walk()
+            if resource.is_file
+        ]
+        if not candidates:
+            return
 
-        for resource in resources_to_remove:
-            resource.remove(codebase)
+        locations = [location for _path, location in candidates]
+        flags = _detect_binaries(locations, processes)
+
+        for (path, _location), binary in zip(candidates, flags):
+            if not binary:
+                continue
+            resource = codebase.get_resource(path)
+            if resource is not None:
+                resource.remove(codebase)
+
+
+def _detect_binaries(locations, processes):
+    """
+    Return a list of booleans, one per location, telling whether it is binary.
+    """
+    if processes and processes > 1 and len(locations) >= PARALLEL_MIN_FILES:
+        try:
+            pool = multiprocessing.Pool(processes)
+        except Exception as ex:
+            logger.debug(f"Parallel binary detection unavailable, using one process: {ex}")
+        else:
+            with pool:
+                return pool.map(is_binary, locations, chunksize=CHUNK_SIZE)
+
+    return [is_binary(location) for location in locations]
 
 
 def is_binary(location):

--- a/src/fosslight_source/run_scancode.py
+++ b/src/fosslight_source/run_scancode.py
@@ -26,6 +26,11 @@ logger = logging.getLogger(constant.LOGGER_NAME)
 warnings.filterwarnings("ignore", category=FutureWarning)
 _PKG_NAME = "fosslight_source"
 
+_MAX_IN_MEMORY_ENV = "FOSSLIGHT_SCANCODE_MAX_IN_MEMORY"
+_SCANCODE_DEFAULT_MAX_IN_MEMORY = 10000
+_MEMORY_FRACTION_FOR_CODEBASE = 0.4
+_BYTES_PER_RESOURCE = 4096
+
 try:
     from click.core import UNSET as _CLICK_UNSET  # Click >= 8.3
     _HAS_CLICK_UNSET = True
@@ -182,6 +187,39 @@ def _default_scancode_ignore_patterns(
     return tuple(sorted(patterns))
 
 
+def _available_memory_bytes() -> int:
+    try:
+        with open("/proc/meminfo") as meminfo:
+            for line in meminfo:
+                if line.startswith("MemAvailable:"):
+                    return int(line.split()[1]) * 1024
+    except OSError:
+        pass
+    try:
+        return os.sysconf("SC_PAGE_SIZE") * os.sysconf("SC_AVPHYS_PAGES")
+    except (AttributeError, ValueError, OSError):
+        return 0
+
+
+def _resolve_max_in_memory() -> int:
+    """
+    Past --max-in-memory resources, ScanCode caches every Resource in its own
+    file under the temp dir, which makes the inventory and every codebase walk
+    disk bound. Raise the threshold to whatever memory allows and let ScanCode
+    keep spilling beyond that.
+    """
+    override = os.environ.get(_MAX_IN_MEMORY_ENV, "").strip()
+    if override:
+        try:
+            return int(override)
+        except ValueError:
+            logger.warning(f"Ignoring invalid {_MAX_IN_MEMORY_ENV}={override}")
+
+    budget = _available_memory_bytes() * _MEMORY_FRACTION_FOR_CODEBASE
+    resolved = int(budget // _BYTES_PER_RESOURCE)
+    return max(resolved, _SCANCODE_DEFAULT_MAX_IN_MEMORY)
+
+
 def run_scan(
     path_to_scan: str, output_file_name: str = "",
     _write_json_file: bool = False, num_cores: int = -1,
@@ -252,9 +290,12 @@ def run_scan(
                     path_to_exclude, abs_path_to_scan
                 )
                 logger.debug(f"Scancode ignore patterns: {len(ignore_tuple)}")
+                max_in_memory = _resolve_max_in_memory()
+                logger.debug(f"Scancode max_in_memory: {max_in_memory}")
 
                 kwargs = {
                     "max_depth": 100,
+                    "max_in_memory": max_in_memory,
                     "strip_root": True,
                     "license": True,
                     "copyright": True,

--- a/tests/test_manifest_android_bp.py
+++ b/tests/test_manifest_android_bp.py
@@ -49,7 +49,7 @@ def test_merge_results_sets_manifest_flag_without_overwriting_scancode_licenses(
 
     assert len(merged) == 1
     assert merged[0].is_manifest_file is True
-    assert merged[0].licenses == ["Apache-2.0", "MIT", "BSD"]
+    assert merged[0].licenses == ["Apache-2.0", "BSD", "MIT"]
 
 
 def test_merge_results_skips_android_bp_not_in_scancode_result():

--- a/tests/test_manifest_recommended_scenarios.py
+++ b/tests/test_manifest_recommended_scenarios.py
@@ -18,7 +18,7 @@ def test_scenario1_android_bp_keeps_scancode_licenses():
 
     assert len(merged) == 1
     assert merged[0].is_manifest_file is True
-    assert merged[0].licenses == ["Apache-2.0", "unknown-license-reference", "BSD", "MIT", "OFL"]
+    assert merged[0].licenses == ["Apache-2.0", "BSD", "MIT", "OFL", "unknown-license-reference"]
 
 
 def test_scenario2_package_json_manifest_fail_keeps_scancode_licenses():

--- a/tests/test_multi_value_order.py
+++ b/tests/test_multi_value_order.py
@@ -1,0 +1,26 @@
+# Copyright (c) 2026 LG Electronics Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Stable order for multi-value License / Copyright cells."""
+
+from fosslight_source._merge import _get_top_merge_values
+from fosslight_source._scan_item import SourceItem
+
+
+def test_licenses_are_stored_sorted():
+    item = SourceItem("dummy.c")
+    item.licenses = ["zlib", "mit", "apache-2.0"]
+    assert item.licenses == ["apache-2.0", "mit", "zlib"]
+
+
+def test_top_merge_copyrights_break_count_ties_alphabetically():
+    items = []
+    for text in ["Copyright Z", "Copyright A", "Copyright Z", "Copyright M"]:
+        item = SourceItem("dummy.c")
+        item.copyright = [text]
+        items.append(item)
+
+    assert _get_top_merge_values(items, lambda i: i.copyright) == [
+        "Copyright Z",
+        "Copyright A",
+        "Copyright M",
+    ]

--- a/tests/test_parsing_unknown_spdx.py
+++ b/tests/test_parsing_unknown_spdx.py
@@ -126,7 +126,7 @@ def test_unknown_spdx_comment_preserves_and_or_from_detected_expression():
     success, results, _messages, _ = parsing_scancode(scancode_file_list)
 
     assert success is True
-    assert results[0].licenses == ["NEW", "DApache-2.0", "GPL-2.0"]
+    assert results[0].licenses == ["DApache-2.0", "GPL-2.0", "NEW"]
     assert "unknown-license-reference" not in [lic.lower() for lic in results[0].licenses]
     assert results[0].comment == "NEW OR DApache-2.0 AND GPL-2.0"
 
@@ -337,10 +337,10 @@ def test_android_bp_soong_license_kinds_without_line_comment_in_license():
     licenses = results[0].licenses
     assert licenses == [
         "Apache-2.0",
-        "unknown-license-reference",
         "BSD",
         "MIT",
         "OFL",
+        "unknown-license-reference",
     ]
     assert all("//" not in lic for lic in results[0].licenses)
     assert all('"' not in lic for lic in results[0].licenses)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - License and copyright results now use consistent, predictable alphabetical ordering.
  - Unknown SPDX license keys are handled more reliably, while recognized license expressions are resolved more efficiently.
  - Large codebases benefit from faster parallel binary detection.
  - ScanCode resource usage now adapts to available system memory and can be customized through configuration.
  - OSS item processing is more efficient without changing output.

- **Tests**
  - Added coverage for deterministic value ordering and updated license-ordering expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->