### PR TITLE
Filter non-URL unknown license references

### DIFF
--- a/src/fosslight_source/_parsing_scancode_file_item.py
+++ b/src/fosslight_source/_parsing_scancode_file_item.py
@@ -34,6 +34,7 @@ KEYWORD_SPDX_ID = r'SPDX-License-Identifier\s*[\S]+'
 KEYWORD_DOWNLOAD_LOC = r'DownloadLocation\s*[\S]+'
 KEYWORD_SCANCODE_UNKNOWN = "unknown-spdx"
 KEYWORD_UNKNOWN_LICENSE_REFERENCE = "unknown-license-reference"
+HTTP_URL_PATTERN = re.compile(r'https?://', re.IGNORECASE)
 SPDX_REPLACE_WORDS = ["(", ")"]
 KEY_AND_OR = re.compile(r"(?<=\s)(?:and|or)(?=\s)", re.IGNORECASE)
 KEY_AND_OR_CAPTURE = re.compile(r"(?<=\s)(and|or)(?=\s)", re.IGNORECASE)
@@ -61,25 +62,41 @@ def filter_fsf_copyright_from_gpl_license_text(
     return [c for c in copyrights if FSF_IN_COPYRIGHT not in c.lower()]
 
 
-def _expression_has_non_unknown_license_reference(license_expression: str) -> bool:
+def _expression_has_other_license(license_expression: str) -> bool:
     if not license_expression:
         return False
     for token in split_spdx_expression(license_expression.lower()):
         token = token.strip()
-        if token and KEYWORD_UNKNOWN_LICENSE_REFERENCE not in token:
+        if (
+            token
+            and KEYWORD_UNKNOWN_LICENSE_REFERENCE not in token
+            and token not in REMOVE_LICENSE
+        ):
             return True
     return False
 
 
-def _matched_texts_with_other_licenses(matches: list) -> set:
-    """matched_text values that also produced a non-unknown-license-reference license."""
-    texts = set()
+def _file_has_other_license(matches: list) -> bool:
+    """Return whether a file has a license other than unknown-license-reference."""
     for matched_lic in matches or []:
-        matched_txt = matched_lic.get("matched_text") or ""
         license_expression = matched_lic.get("license_expression") or ""
-        if matched_txt and _expression_has_non_unknown_license_reference(license_expression):
-            texts.add(matched_txt)
-    return texts
+        if _expression_has_other_license(license_expression):
+            return True
+    return False
+
+
+def _matched_text_has_http_url(matched_text: str) -> bool:
+    """Return whether matched text contains an HTTP or HTTPS URL."""
+    return bool(HTTP_URL_PATTERN.search(matched_text or ""))
+
+
+def _should_keep_unknown_license_reference(
+    matched_text: str, has_other_license_in_file: bool
+) -> bool:
+    return (
+        not has_other_license_in_file
+        and _matched_text_has_http_url(matched_text)
+    )
 
 
 def get_error_from_header(header_item: list) -> Tuple[bool, str]:
@@ -424,23 +441,25 @@ def _build_unknown_spdx_replacement_queue(matches: list) -> list[str]:
 
 
 def _should_suppress_unknown_license_reference(
-    matches: list, matched_texts_with_other_licenses: set
+    matches: list, has_other_license_in_file: bool
 ) -> bool:
+    has_unknown_license_reference = False
     for matched_lic in matches or []:
         expr = (matched_lic.get("license_expression") or "").lower()
-        matched_txt = matched_lic.get("matched_text") or ""
-        if (
-            KEYWORD_UNKNOWN_LICENSE_REFERENCE in expr
-            and matched_txt in matched_texts_with_other_licenses
+        if KEYWORD_UNKNOWN_LICENSE_REFERENCE not in expr:
+            continue
+        has_unknown_license_reference = True
+        if _should_keep_unknown_license_reference(
+            matched_lic.get("matched_text") or "", has_other_license_in_file
         ):
-            return True
-    return False
+            return False
+    return has_unknown_license_reference
 
 
 def build_comment_from_detected_expression(
     detected_expression: str,
     matches: list,
-    matched_texts_with_other_licenses: set,
+    suppress_unknown_license_reference: bool,
 ) -> str:
     """
     Rebuild comment from detected expression.
@@ -470,14 +489,11 @@ def build_comment_from_detected_expression(
         )
 
     replacements = _build_unknown_spdx_replacement_queue(matches)
-    suppress_ulr = _should_suppress_unknown_license_reference(
-        matches, matched_texts_with_other_licenses
-    )
     tree = _parse_license_expression_tokens(_tokenize_license_expression(expr))
     if tree is None:
         return ""
     transformed = _transform_license_expr_node(
-        tree, replacements, [0], suppress_ulr
+        tree, replacements, [0], suppress_unknown_license_reference
     )
     return _omit_parens_for_two_license_expression(
         _serialize_license_expr_node(transformed)
@@ -545,7 +561,12 @@ def parsing_scancode(
                 all_matches = []
                 for lic in licenses or []:
                     all_matches.extend(lic.get("matches") or [])
-                matched_texts_with_other_licenses = _matched_texts_with_other_licenses(all_matches)
+                has_other_license_in_file = _file_has_other_license(all_matches)
+                suppress_unknown_license_reference = (
+                    _should_suppress_unknown_license_reference(
+                        all_matches, has_other_license_in_file
+                    )
+                )
                 for lic in licenses or []:
                     matched_lic_list = lic.get("matches", [])
                     for matched_lic in matched_lic_list:
@@ -565,7 +586,9 @@ def parsing_scancode(
                                         continue
                                     if (
                                         KEYWORD_UNKNOWN_LICENSE_REFERENCE in found_lic.lower()
-                                        and matched_txt in matched_texts_with_other_licenses
+                                        and not _should_keep_unknown_license_reference(
+                                            matched_txt, has_other_license_in_file
+                                        )
                                     ):
                                         continue
                                     if KEYWORD_SCANCODE_UNKNOWN in found_lic.lower():
@@ -603,6 +626,7 @@ def parsing_scancode(
                         resolved_unknown_spdx
                         or KEYWORD_SCANCODE_UNKNOWN in detected_expression.lower()
                         or "licenseref-scancode-unknown-spdx" in detected_expression_spdx.lower()
+                        or suppress_unknown_license_reference
                     ):
                         # Prefer non-SPDX expression so unknown-spdx tokens map cleanly.
                         # Comment only for dual-license style expressions that include OR.
@@ -611,7 +635,7 @@ def parsing_scancode(
                             result_item.comment = build_comment_from_detected_expression(
                                 source_expression,
                                 all_matches,
-                                matched_texts_with_other_licenses,
+                                suppress_unknown_license_reference,
                             )
                     else:
                         license_expression = detected_expression_spdx or detected_expression

--- a/tests/test_parsing_unknown_spdx.py
+++ b/tests/test_parsing_unknown_spdx.py
@@ -9,7 +9,9 @@ from fosslight_source._parsing_scancode_file_item import (
     _declared_licenses_from_matched_text,
     build_comment_from_detected_expression,
     parsing_scancode,
-    _matched_texts_with_other_licenses,
+    _file_has_other_license,
+    _matched_text_has_http_url,
+    _should_suppress_unknown_license_reference,
 )
 
 
@@ -157,6 +159,168 @@ def test_unknown_license_reference_suppressed_when_same_matched_text_has_other_l
     assert results[0].licenses == ["GPL-2.0"]
 
 
+@pytest.mark.parametrize(
+    "matched_text",
+    [
+        "License terms: http://example.com/license",
+        "License terms: https://example.com/license",
+        "License terms: HTTPS://example.com/license",
+    ],
+)
+def test_unknown_license_reference_kept_when_it_is_only_license_with_url(matched_text):
+    scancode_file_list = [{
+        "path": "reference.txt",
+        "type": "file",
+        "license_detections": [{
+            "matches": [{
+                "license_expression": "unknown-license-reference",
+                "matched_text": matched_text,
+            }],
+        }],
+        "copyrights": [],
+    }]
+
+    success, results, _messages, license_list = parsing_scancode(scancode_file_list)
+
+    assert success is True
+    assert results[0].licenses == ["unknown-license-reference"]
+    assert [item.matched_text for item in license_list.values()] == [matched_text]
+
+
+@pytest.mark.parametrize("matched_text", ["See the accompanying license", "", None])
+def test_unknown_license_reference_suppressed_without_url(matched_text):
+    scancode_file_list = [{
+        "path": "reference.txt",
+        "type": "file",
+        "license_detections": [{
+            "matches": [{
+                "license_expression": "unknown-license-reference",
+                "matched_text": matched_text,
+            }],
+        }],
+        "copyrights": [],
+    }]
+
+    success, results, _messages, license_list = parsing_scancode(scancode_file_list)
+
+    assert success is True
+    assert results[0].licenses == []
+    assert license_list == {}
+
+
+def test_unknown_license_reference_suppressed_by_other_license_in_same_file():
+    reference_text = "License terms: https://example.com/license"
+    scancode_file_list = [{
+        "path": "mixed.txt",
+        "type": "file",
+        "detected_license_expression": (
+            "unknown-license-reference OR mit OR apache-2.0"
+        ),
+        "license_detections": [{
+            "matches": [
+                {
+                    "license_expression": "unknown-license-reference",
+                    "matched_text": reference_text,
+                },
+                {
+                    "license_expression": "mit",
+                    "matched_text": "Permission is hereby granted, free of charge...",
+                },
+                {
+                    "license_expression": "apache-2.0",
+                    "matched_text": "Licensed under the Apache License, Version 2.0",
+                },
+            ],
+        }],
+        "copyrights": [],
+    }]
+
+    success, results, _messages, license_list = parsing_scancode(scancode_file_list)
+
+    assert success is True
+    assert results[0].licenses == ["MIT", "Apache-2.0"]
+    assert results[0].comment == "MIT OR Apache-2.0"
+    assert all(
+        item.license != "unknown-license-reference"
+        for item in license_list.values()
+    )
+
+
+def test_unknown_license_reference_filter_is_scoped_to_each_file():
+    reference_text = "License terms: https://example.com/license"
+    scancode_file_list = [
+        {
+            "path": "reference.txt",
+            "type": "file",
+            "license_detections": [{
+                "matches": [{
+                    "license_expression": "unknown-license-reference",
+                    "matched_text": reference_text,
+                }],
+            }],
+            "copyrights": [],
+        },
+        {
+            "path": "mit.txt",
+            "type": "file",
+            "license_detections": [{
+                "matches": [{
+                    "license_expression": "mit",
+                    "matched_text": "Permission is hereby granted, free of charge...",
+                }],
+            }],
+            "copyrights": [],
+        },
+    ]
+
+    success, results, _messages, _license_list = parsing_scancode(scancode_file_list)
+
+    assert success is True
+    assert results[0].licenses == ["unknown-license-reference"]
+    assert results[1].licenses == ["MIT"]
+
+
+def test_only_url_backed_unknown_license_reference_is_reported():
+    valid_text = "License terms: https://example.com/license"
+    invalid_text = "See the accompanying license"
+    scancode_file_list = [{
+        "path": "references.txt",
+        "type": "file",
+        "license_detections": [{
+            "matches": [
+                {
+                    "license_expression": "unknown-license-reference",
+                    "matched_text": invalid_text,
+                },
+                {
+                    "license_expression": "unknown-license-reference",
+                    "matched_text": valid_text,
+                },
+            ],
+        }],
+        "copyrights": [],
+    }]
+
+    success, results, _messages, license_list = parsing_scancode(scancode_file_list)
+
+    assert success is True
+    assert results[0].licenses == ["unknown-license-reference"]
+    assert [item.matched_text for item in license_list.values()] == [valid_text]
+
+
+@pytest.mark.parametrize(
+    ("matched_text", "expected"),
+    [
+        ("http://example.com/license", True),
+        ("HTTPS://example.com/license", True),
+        ("ftp://example.com/license", False),
+        (None, False),
+    ],
+)
+def test_matched_text_has_http_url(matched_text, expected):
+    assert _matched_text_has_http_url(matched_text) is expected
+
+
 def test_licenseref_tokens_stripped_from_unknown_spdx_and_expression():
     scancode_file_list = [{
         "path": "refs.py",
@@ -196,11 +360,11 @@ def test_build_comment_from_detected_expression_helper():
             "matched_text": matched_same,
         },
     ]
-    other_texts = _matched_texts_with_other_licenses(matches)
+    has_other_license = _file_has_other_license(matches)
     comment = build_comment_from_detected_expression(
         "(unknown-spdx OR unknown-spdx) AND unknown-license-reference AND gpl-2.0",
         matches,
-        other_texts,
+        _should_suppress_unknown_license_reference(matches, has_other_license),
     )
     assert comment == "NEW OR DApache-2.0 AND GPL-2.0"
 
@@ -216,7 +380,7 @@ def test_comment_without_parens_uses_operator_before_kept_token():
     comment = build_comment_from_detected_expression(
         "mit OR unknown-license-reference AND apache-2.0",
         matches,
-        {matched_same},
+        True,
     )
     assert comment == "MIT AND Apache-2.0"
 
@@ -232,7 +396,7 @@ def test_comment_with_parens_preserves_or_group():
     comment = build_comment_from_detected_expression(
         "mit OR (unknown-license-reference AND apache-2.0)",
         matches,
-        {matched_same},
+        True,
     )
     assert comment == "MIT OR Apache-2.0"
 
@@ -248,7 +412,7 @@ def test_comment_with_parens_preserves_and_after_group():
     comment = build_comment_from_detected_expression(
         "(mit OR unknown-license-reference) AND apache-2.0",
         matches,
-        {matched_same},
+        True,
     )
     assert comment == "MIT AND Apache-2.0"
 
@@ -337,7 +501,6 @@ def test_android_bp_soong_license_kinds_without_line_comment_in_license():
     licenses = results[0].licenses
     assert licenses == [
         "Apache-2.0",
-        "unknown-license-reference",
         "BSD",
         "MIT",
         "OFL",


### PR DESCRIPTION
Remove non-URL unknown license references from license results if other license exists


 | | 이전 | 이번 커밋
| -- | -- | --
unknown-license-reference 유지 조건 | 같은 matched_text에 다른 라이선스가 없을 때 | 파일에 다른 라이선스가 없고 + matched_text에 http(s)://가 있을 때
