### PR TITLE
Own EXCLUDE_FILENAME_SOURCE in source scanner

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "pyparsing",
     "scanoss>=1.45.0",
     "XlsxWriter",
-    "fosslight_util>=2.2.11",
+    "fosslight_util>=2.2.12",
     "PyYAML",
     "wheel>=0.38.1",
     "intbitset",

--- a/src/fosslight_source/_exclude.py
+++ b/src/fosslight_source/_exclude.py
@@ -1,0 +1,21 @@
+# Copyright (c) 2026 LG Electronics Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Source-scanner filename excludes (not applied to dependency discovery)."""
+
+from fosslight_util.exclude import is_excluded_filename
+
+# Build/package config noise for license scans.
+EXCLUDE_FILENAME_SOURCE = frozenset({
+    "changelog", "config.guess", "config.sub", "changes", "ltmain.sh",
+    "configure", "configure.ac", "depcomp", "compile", "missing", "makefile",
+    "makefile.am",
+    "build.gradle", "build.gradle.kts", "settings.gradle", "settings.gradle.kts",
+    "gradlew", "gradlew.bat",
+    "vite.config.ts", "vite.config.js", "vite.config.mts", "vite.config.mjs",
+    "package-lock.json", "npm-shrinkwrap.json", "yarn.lock", "pnpm-lock.yaml",
+})
+
+
+def is_excluded_source_filename(file_path: str) -> bool:
+    return is_excluded_filename(file_path, EXCLUDE_FILENAME_SOURCE)

--- a/src/fosslight_source/_parsing_scancode_file_item.py
+++ b/src/fosslight_source/_parsing_scancode_file_item.py
@@ -8,7 +8,7 @@ import logging
 import re
 from functools import lru_cache
 import fosslight_util.constant as constant
-from fosslight_util.exclude import is_excluded_filename
+from ._exclude import is_excluded_source_filename
 from ._license_matched import MatchedLicense
 from ._scan_item import SourceItem
 from ._scan_item import replace_word
@@ -545,7 +545,7 @@ def parsing_scancode(
                 if (not file_path) or is_binary or is_dir:
                     logger.info(f"Skipping {file_path} because it is binary or directory")
                     continue
-                if is_excluded_filename(file_path):
+                if is_excluded_source_filename(file_path):
                     logger.debug(f"Skipping {file_path} because it is an excluded filename")
                     continue
                 result_item = SourceItem(file_path)

--- a/src/fosslight_source/_parsing_scanoss_file.py
+++ b/src/fosslight_source/_parsing_scanoss_file.py
@@ -5,6 +5,7 @@
 
 import logging
 import fosslight_util.constant as constant
+from ._exclude import is_excluded_source_filename
 from ._scan_item import SourceItem
 from ._scan_item import replace_word
 from typing import Tuple
@@ -39,7 +40,7 @@ def parsing_scan_result(scanoss_report: dict, excluded_files: set = None) -> Tup
 
     for file_path, findings in scanoss_report.items():
         file_path_normalized = file_path.replace('\\', '/')
-        if file_path_normalized in excluded_files:
+        if file_path_normalized in excluded_files or is_excluded_source_filename(file_path_normalized):
             continue
         result_item = SourceItem(file_path)
 

--- a/src/fosslight_source/cli.py
+++ b/src/fosslight_source/cli.py
@@ -22,6 +22,7 @@ from fosslight_util.correct import correct_with_yaml
 from fosslight_util.parsing_yaml import SUPPORT_OSS_INFO_FILES
 from .run_scancode import run_scan
 from fosslight_util.exclude import get_excluded_paths
+from ._exclude import EXCLUDE_FILENAME_SOURCE, is_excluded_source_filename
 from .run_scanoss import run_scanoss_py
 from .run_scanoss import get_scanoss_extra_info
 import yaml
@@ -380,7 +381,8 @@ def _collect_kb_file_hashes(
 
     for file_path in tqdm.tqdm(files_to_scan, desc="KB Hashing", disable=hide_progress):
         rel_path = os.path.relpath(file_path, abs_path_to_scan).replace("\\", "/")
-        if rel_path in scancode_paths or rel_path in excluded_files or is_notice_file(file_path):
+        if (rel_path in scancode_paths or rel_path in excluded_files
+                or is_excluded_source_filename(rel_path) or is_notice_file(file_path)):
             continue
         extra_item = SourceItem(rel_path)
         md5_hash, _wfp = extra_item._get_hash(path_to_scan)
@@ -629,7 +631,9 @@ def run_scanners(
                 (excluded_path_with_default_exclusion,
                  excluded_path_without_dot,
                  excluded_files,
-                 cnt_file_except_skipped) = get_excluded_paths(path_to_scan, path_to_exclude_with_filename)
+                 cnt_file_except_skipped) = get_excluded_paths(
+                    path_to_scan, path_to_exclude_with_filename,
+                    exclude_filenames=EXCLUDE_FILENAME_SOURCE)
                 logger.debug(f"Skipped paths count: {len(excluded_path_with_default_exclusion)}")
 
             if not selected_scanner:
@@ -727,7 +731,7 @@ def metadata_collector(path_to_scan: str, excluded_files: set) -> tuple[dict, di
         for file in files:
             file_path = os.path.join(root, file)
             rel_path_file = os.path.relpath(file_path, abs_path_to_scan).replace('\\', '/')
-            if rel_path_file in excluded_files:
+            if rel_path_file in excluded_files or is_excluded_source_filename(rel_path_file):
                 continue
 
             downloads = get_spdx_downloads(file_path)

--- a/src/fosslight_source/run_scancode.py
+++ b/src/fosslight_source/run_scancode.py
@@ -170,7 +170,7 @@ def _default_scancode_ignore_patterns(
     Directory names use path-based globs (e.g. **/tests/**) so they do not match
     the scan root directory name itself.
     Binary files are excluded separately via scancode --ignore-binaries.
-    EXCLUDE_FILENAME is not passed to ScanCode --ignore: matching many exact
+    EXCLUDE_FILENAME_SOURCE is not passed to ScanCode --ignore: matching many exact
     names on a large tree is slow. Those files are dropped after parsing.
     """
     patterns = {".*"}


### PR DESCRIPTION
Move basename excludes out of fosslight_util and apply them locally so
shared all-mode exclude can omit them.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Source scanning now excludes common build and package configuration files, including makefiles, Gradle and Vite configuration files, lockfiles, and similar artifacts.
  - Excluded filenames are consistently omitted from ScanCode and ScanOSS results, file-hash collection, metadata collection, and excluded-path processing.
  - ScanCode ignore-pattern documentation now clarifies how these files are handled after parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->