### PR TITLE
fix(manifest): keep scancode licenses when manifest empty

### DIFF
--- a/src/fosslight_source/cli.py
+++ b/src/fosslight_source/cli.py
@@ -461,8 +461,10 @@ def merge_results(
             if item is None:
                 continue
             item.is_manifest_file = True
+            # Overwrite ScanCode licenses only when manifest extraction found at least one
+            # license. Empty results (parse failure, Android.bp, license-file-only fields,
+            # SEE LICENSE IN, etc.) must keep existing ScanCode licenses.
             if valid_licenses:
-                # overwrite existing detected licenses with manifest-provided licenses
                 item.licenses = []  # clear existing licenses (setter clears when value falsy)
                 item.licenses = valid_licenses
 

--- a/src/fosslight_source/cli.py
+++ b/src/fosslight_source/cli.py
@@ -455,17 +455,20 @@ def merge_results(
     if manifest_licenses:
         for file_name, licenses in manifest_licenses.items():
             valid_licenses = [lic.strip() for lic in licenses if isinstance(lic, str) and lic.strip()]
+            is_android_bp = os.path.basename(str(file_name)).lower() == "android.bp"
             item = _get_or_append_source_item(
                 scancode_result, file_name, append=bool(valid_licenses) or ui_mode
             )
             if item is None:
                 continue
             item.is_manifest_file = True
-            # Overwrite ScanCode licenses only when manifest extraction found at least one
-            # license. Empty results (parse failure, Android.bp, license-file-only fields,
-            # SEE LICENSE IN, etc.) must keep existing ScanCode licenses.
+            # Android.bp is a marker only: keep ScanCode licenses.
+            # All other manifests always apply extracted licenses, including empty,
+            # so a blank/unresolved manifest license clears ScanCode licenses.
+            if is_android_bp:
+                continue
+            item.licenses = []
             if valid_licenses:
-                item.licenses = []  # clear existing licenses (setter clears when value falsy)
                 item.licenses = valid_licenses
 
     kb_origin_urls: dict[str, str] = {}

--- a/src/fosslight_source/cli.py
+++ b/src/fosslight_source/cli.py
@@ -454,18 +454,19 @@ def merge_results(
                 scancode_result.append(new_result_item)
     if manifest_licenses:
         for file_name, licenses in manifest_licenses.items():
-            valid_licenses = [lic.strip() for lic in licenses if isinstance(lic, str) and lic.strip()]
-            is_android_bp = os.path.basename(str(file_name)).lower() == "android.bp"
+            # None: marker-only (keep ScanCode). list (incl. []): overwrite with extracted result.
+            keep_scancode_licenses = licenses is None
+            license_list = [] if keep_scancode_licenses else licenses
+            valid_licenses = [
+                lic.strip() for lic in license_list if isinstance(lic, str) and lic.strip()
+            ]
             item = _get_or_append_source_item(
                 scancode_result, file_name, append=bool(valid_licenses) or ui_mode
             )
             if item is None:
                 continue
             item.is_manifest_file = True
-            # Android.bp is a marker only: keep ScanCode licenses.
-            # All other manifests always apply extracted licenses, including empty,
-            # so a blank/unresolved manifest license clears ScanCode licenses.
-            if is_android_bp:
+            if keep_scancode_licenses:
                 continue
             item.licenses = []
             if valid_licenses:
@@ -724,7 +725,9 @@ def metadata_collector(path_to_scan: str, excluded_files: set) -> tuple[dict, di
 
     - Traverse files with exclusions applied
     - spdx_downloads: {rel_path: [download_urls]}
-    - manifest_licenses: {rel_path: [license_names]} (empty list if extraction failed)
+    - manifest_licenses: {rel_path: list[str] | None}
+        - list (incl. []): overwrite ScanCode licenses with this result
+        - None: marker-only; keep ScanCode licenses
 
     :return: (spdx_downloads, manifest_licenses)
     """
@@ -744,7 +747,8 @@ def metadata_collector(path_to_scan: str, excluded_files: set) -> tuple[dict, di
                 spdx_downloads[rel_path_file] = downloads
 
             if is_manifest_file(file_path):
-                manifest_licenses[rel_path_file] = get_manifest_licenses(file_path) or []
+                # Preserve None (marker-only); do not coerce with `or []`.
+                manifest_licenses[rel_path_file] = get_manifest_licenses(file_path)
 
     return spdx_downloads, manifest_licenses
 

--- a/src/fosslight_source/run_manifest_extractor.py
+++ b/src/fosslight_source/run_manifest_extractor.py
@@ -6,6 +6,7 @@ import os
 import json
 import re
 import logging
+from typing import Optional
 from fosslight_util.get_pom_license import get_license_from_pom
 import fosslight_util.constant as constant
 
@@ -382,11 +383,15 @@ def get_licenses_from_huggingface_metadata(file_path: str) -> list[str]:
     return licenses
 
 
-def get_manifest_licenses(file_path: str) -> list[str]:
-    # Empty return is applied as-is in merge (clears ScanCode licenses), except Android.bp
-    # which is a marker only and keeps ScanCode licenses.
+def get_manifest_licenses(file_path: str) -> Optional[list[str]]:
+    """Extract licenses from a manifest file.
+
+    Returns:
+        list[str]: licenses to apply in merge (empty list clears ScanCode licenses).
+        None: marker-only manifest; merge sets is_manifest_file and keeps ScanCode licenses.
+    """
     if os.path.basename(file_path).lower() == 'android.bp':
-        return []
+        return None
     if file_path.endswith('.pom'):
         try:
             pom_licenses = get_license_from_pom(group_id='', artifact_id='', version='', pom_path=file_path, check_parent=True)
@@ -444,3 +449,4 @@ def get_manifest_licenses(file_path: str) -> list[str]:
         except Exception as ex:
             logger.info(f"Failed to extract license from huggingface_hub_metadata.json {file_path}: {ex}")
             return []
+    return []

--- a/src/fosslight_source/run_manifest_extractor.py
+++ b/src/fosslight_source/run_manifest_extractor.py
@@ -124,7 +124,7 @@ def get_licenses_from_setup_cfg(file_path: str) -> list[str]:
         if parser.has_section('metadata'):
             license_value = parser.get('metadata', 'license', fallback='').strip()
             if license_value:
-                # license = LICENSE is a file reference; treat as not found (keep ScanCode).
+                # license = LICENSE is a file reference; treat as empty (clears ScanCode on merge).
                 if _is_setup_cfg_license_file_ref(license_value):
                     return []
                 return _split_spdx_expression(license_value)
@@ -383,8 +383,8 @@ def get_licenses_from_huggingface_metadata(file_path: str) -> list[str]:
 
 
 def get_manifest_licenses(file_path: str) -> list[str]:
-    # Empty return means merge keeps ScanCode licenses and only sets is_manifest_file
-    # (Android.bp, extraction failure, license-file-only metadata, etc.).
+    # Empty return is applied as-is in merge (clears ScanCode licenses), except Android.bp
+    # which is a marker only and keeps ScanCode licenses.
     if os.path.basename(file_path).lower() == 'android.bp':
         return []
     if file_path.endswith('.pom'):

--- a/src/fosslight_source/run_manifest_extractor.py
+++ b/src/fosslight_source/run_manifest_extractor.py
@@ -373,7 +373,8 @@ def get_licenses_from_huggingface_metadata(file_path: str) -> list[str]:
 
 
 def get_manifest_licenses(file_path: str) -> list[str]:
-    # Android.bp licenses come from ScanCode; manifest merge only sets is_manifest_file.
+    # Empty return means merge keeps ScanCode licenses and only sets is_manifest_file
+    # (Android.bp, extraction failure, license-file-only metadata, etc.).
     if os.path.basename(file_path).lower() == 'android.bp':
         return []
     if file_path.endswith('.pom'):

--- a/src/fosslight_source/run_manifest_extractor.py
+++ b/src/fosslight_source/run_manifest_extractor.py
@@ -111,6 +111,11 @@ def get_licenses_from_composer_json(file_path: str) -> list[str]:
     return unique
 
 
+def _is_setup_cfg_license_file_ref(value: str) -> bool:
+    """True when setup.cfg license points at a LICENSE file name, not an SPDX id."""
+    return value.strip().upper() == 'LICENSE'
+
+
 def get_licenses_from_setup_cfg(file_path: str) -> list[str]:
     try:
         import configparser
@@ -119,6 +124,9 @@ def get_licenses_from_setup_cfg(file_path: str) -> list[str]:
         if parser.has_section('metadata'):
             license_value = parser.get('metadata', 'license', fallback='').strip()
             if license_value:
+                # license = LICENSE is a file reference; treat as not found (keep ScanCode).
+                if _is_setup_cfg_license_file_ref(license_value):
+                    return []
                 return _split_spdx_expression(license_value)
     except Exception as ex:
         logger.info(f"Failed to parse setup.cfg with configparser for {file_path}: {ex}")
@@ -137,6 +145,8 @@ def get_licenses_from_setup_cfg(file_path: str) -> list[str]:
         if (len(val) >= 2) and ((val[0] == val[-1]) and val[0] in ('"', "'")):
             val = val[1:-1].strip()
         if not val:
+            return []
+        if _is_setup_cfg_license_file_ref(val):
             return []
         return _split_spdx_expression(val)
     except Exception as ex:

--- a/tests/test_manifest_android_bp.py
+++ b/tests/test_manifest_android_bp.py
@@ -18,10 +18,10 @@ def test_is_manifest_file_recognizes_android_bp():
     assert is_manifest_file("/tmp/module/package.json") is True
 
 
-def test_get_manifest_licenses_returns_empty_for_android_bp(tmp_path):
+def test_get_manifest_licenses_returns_none_for_android_bp(tmp_path):
     android_bp = tmp_path / "Android.bp"
     android_bp.write_text('license { name: "test_license" }', encoding="utf-8")
-    assert get_manifest_licenses(str(android_bp)) == []
+    assert get_manifest_licenses(str(android_bp)) is None
 
 
 def test_metadata_collector_adds_android_bp_without_license_extraction(tmp_path):
@@ -34,7 +34,7 @@ def test_metadata_collector_adds_android_bp_without_license_extraction(tmp_path)
         spdx_downloads, manifest_licenses = metadata_collector(str(tmp_path), set())
 
     assert spdx_downloads == {}
-    assert manifest_licenses == {"Android.bp": [], "package.json": ["MIT"]}
+    assert manifest_licenses == {"Android.bp": None, "package.json": ["MIT"]}
     assert mock_get.call_count == 2
 
 
@@ -44,7 +44,7 @@ def test_merge_results_sets_manifest_flag_without_overwriting_scancode_licenses(
 
     merged, _, _, _ = merge_results(
         scancode_result=[scancode_item],
-        manifest_licenses={"carrois-gothic-sc/Android.bp": []},
+        manifest_licenses={"carrois-gothic-sc/Android.bp": None},
     )
 
     assert len(merged) == 1
@@ -55,7 +55,7 @@ def test_merge_results_sets_manifest_flag_without_overwriting_scancode_licenses(
 def test_merge_results_skips_android_bp_not_in_scancode_result():
     merged, _, _, _ = merge_results(
         scancode_result=[],
-        manifest_licenses={"module/Android.bp": []},
+        manifest_licenses={"module/Android.bp": None},
     )
 
     assert merged == []

--- a/tests/test_manifest_recommended_scenarios.py
+++ b/tests/test_manifest_recommended_scenarios.py
@@ -13,7 +13,7 @@ def test_scenario1_android_bp_keeps_scancode_licenses():
 
     merged, _, _, _ = merge_results(
         scancode_result=[scancode_item],
-        manifest_licenses={"Android.bp": []},
+        manifest_licenses={"Android.bp": None},
     )
 
     assert len(merged) == 1
@@ -60,7 +60,7 @@ def test_scenario3_android_bp_from_spdx_marks_manifest_without_new_row():
 
     merged, _, _, _ = merge_results(
         scancode_result=[spdx_item],
-        manifest_licenses={"module/Android.bp": []},
+        manifest_licenses={"module/Android.bp": None},
     )
 
     assert len(merged) == 1
@@ -73,7 +73,7 @@ def test_scenario3_android_bp_not_in_result_no_row_non_ui():
     """Android.bp absent from merge result: no row in non-UI mode."""
     merged_non_ui, _, _, _ = merge_results(
         scancode_result=[],
-        manifest_licenses={"module/Android.bp": []},
+        manifest_licenses={"module/Android.bp": None},
         ui_mode=False,
     )
     assert merged_non_ui == []
@@ -83,7 +83,7 @@ def test_scenario3_android_bp_not_in_result_ui_keeps_empty_row():
     """Android.bp absent from merge result: UI mode still creates manifest row."""
     merged_ui, _, _, _ = merge_results(
         scancode_result=[],
-        manifest_licenses={"module/Android.bp": []},
+        manifest_licenses={"module/Android.bp": None},
         ui_mode=True,
     )
 

--- a/tests/test_manifest_recommended_scenarios.py
+++ b/tests/test_manifest_recommended_scenarios.py
@@ -21,10 +21,11 @@ def test_scenario1_android_bp_keeps_scancode_licenses():
     assert merged[0].licenses == ["Apache-2.0", "BSD", "MIT", "OFL", "unknown-license-reference"]
 
 
-def test_scenario2_package_json_manifest_fail_keeps_scancode_licenses():
-    """package.json manifest extraction fails but ScanCode row exists: manifest flag only."""
+def test_scenario2_package_json_empty_clears_scancode_licenses():
+    """package.json empty manifest licenses overwrite/clear ScanCode licenses."""
     scancode_item = SourceItem("app/package.json")
     scancode_item.licenses = ["Apache-2.0"]
+    scancode_item.download_location = ["https://example.com/app"]
 
     merged, _, _, _ = merge_results(
         scancode_result=[scancode_item],
@@ -33,13 +34,14 @@ def test_scenario2_package_json_manifest_fail_keeps_scancode_licenses():
 
     assert len(merged) == 1
     assert merged[0].is_manifest_file is True
-    assert merged[0].licenses == ["Apache-2.0"]
+    assert merged[0].licenses == []
 
 
-def test_scenario2_pyproject_license_file_keeps_scancode_licenses():
-    """pyproject.toml license={file=...} yields []; ScanCode licenses must not be cleared."""
+def test_scenario2_pyproject_license_file_clears_scancode_licenses():
+    """pyproject.toml license={file=...} yields []; ScanCode licenses are cleared."""
     scancode_item = SourceItem("tornado/pyproject.toml")
     scancode_item.licenses = ["Apache-2.0"]
+    scancode_item.download_location = ["https://example.com/tornado"]
 
     merged, _, _, _ = merge_results(
         scancode_result=[scancode_item],
@@ -48,7 +50,7 @@ def test_scenario2_pyproject_license_file_keeps_scancode_licenses():
 
     assert len(merged) == 1
     assert merged[0].is_manifest_file is True
-    assert merged[0].licenses == ["Apache-2.0"]
+    assert merged[0].licenses == []
 
 
 def test_scenario3_android_bp_from_spdx_marks_manifest_without_new_row():

--- a/tests/test_manifest_recommended_scenarios.py
+++ b/tests/test_manifest_recommended_scenarios.py
@@ -36,6 +36,21 @@ def test_scenario2_package_json_manifest_fail_keeps_scancode_licenses():
     assert merged[0].licenses == ["Apache-2.0"]
 
 
+def test_scenario2_pyproject_license_file_keeps_scancode_licenses():
+    """pyproject.toml license={file=...} yields []; ScanCode licenses must not be cleared."""
+    scancode_item = SourceItem("tornado/pyproject.toml")
+    scancode_item.licenses = ["Apache-2.0"]
+
+    merged, _, _, _ = merge_results(
+        scancode_result=[scancode_item],
+        manifest_licenses={"tornado/pyproject.toml": []},
+    )
+
+    assert len(merged) == 1
+    assert merged[0].is_manifest_file is True
+    assert merged[0].licenses == ["Apache-2.0"]
+
+
 def test_scenario3_android_bp_from_spdx_marks_manifest_without_new_row():
     """Android.bp added by spdx merge: manifest flag on existing item, no duplicate row."""
     spdx_item = SourceItem("module/Android.bp")

--- a/tests/test_manifest_setup_cfg.py
+++ b/tests/test_manifest_setup_cfg.py
@@ -25,16 +25,17 @@ def test_setup_cfg_license_filename_case_insensitive(tmp_path):
     assert get_licenses_from_setup_cfg(str(path)) == []
 
 
-def test_setup_cfg_license_filename_keeps_scancode_licenses(tmp_path):
+def test_setup_cfg_license_filename_clears_scancode_licenses(tmp_path):
     path = tmp_path / "setup.cfg"
     path.write_text("[metadata]\nname = demo\nlicense = LICENSE\n", encoding="utf-8")
     assert get_licenses_from_setup_cfg(str(path)) == []
 
     scancode_item = SourceItem("pkg/setup.cfg")
     scancode_item.licenses = ["Apache-2.0"]
+    scancode_item.download_location = ["https://example.com/pkg"]
     merged, _, _, _ = merge_results(
         scancode_result=[scancode_item],
         manifest_licenses={"pkg/setup.cfg": []},
     )
     assert merged[0].is_manifest_file is True
-    assert merged[0].licenses == ["Apache-2.0"]
+    assert merged[0].licenses == []

--- a/tests/test_manifest_setup_cfg.py
+++ b/tests/test_manifest_setup_cfg.py
@@ -1,0 +1,40 @@
+# Copyright (c) 2026 LG Electronics Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for setup.cfg manifest license extraction."""
+
+from fosslight_source._scan_item import SourceItem
+from fosslight_source.cli import merge_results
+from fosslight_source.run_manifest_extractor import get_licenses_from_setup_cfg
+
+
+def test_setup_cfg_spdx_license(tmp_path):
+    path = tmp_path / "setup.cfg"
+    path.write_text("[metadata]\nname = demo\nlicense = MIT\n", encoding="utf-8")
+    assert get_licenses_from_setup_cfg(str(path)) == ["MIT"]
+
+
+def test_setup_cfg_license_filename_returns_empty(tmp_path):
+    path = tmp_path / "setup.cfg"
+    path.write_text("[metadata]\nname = demo\nlicense = LICENSE\n", encoding="utf-8")
+    assert get_licenses_from_setup_cfg(str(path)) == []
+
+
+def test_setup_cfg_license_filename_case_insensitive(tmp_path):
+    path = tmp_path / "setup.cfg"
+    path.write_text("[metadata]\nname = demo\nlicense = License\n", encoding="utf-8")
+    assert get_licenses_from_setup_cfg(str(path)) == []
+
+
+def test_setup_cfg_license_filename_keeps_scancode_licenses(tmp_path):
+    path = tmp_path / "setup.cfg"
+    path.write_text("[metadata]\nname = demo\nlicense = LICENSE\n", encoding="utf-8")
+    assert get_licenses_from_setup_cfg(str(path)) == []
+
+    scancode_item = SourceItem("pkg/setup.cfg")
+    scancode_item.licenses = ["Apache-2.0"]
+    merged, _, _, _ = merge_results(
+        scancode_result=[scancode_item],
+        manifest_licenses={"pkg/setup.cfg": []},
+    )
+    assert merged[0].is_manifest_file is True
+    assert merged[0].licenses == ["Apache-2.0"]


### PR DESCRIPTION
## Summary
- Keep ScanCode licenses when manifest license extraction returns empty (`[]`), including parse failure, Android.bp, and license-file-only metadata (e.g. pyproject `{file=...}`).
- Clarify merge comments and add a pyproject.toml regression test.