### PR TITLE
fix(scancode): tighten unknown-spdx restoration rules

### DIFF
--- a/src/fosslight_source/_parsing_scancode_file_item.py
+++ b/src/fosslight_source/_parsing_scancode_file_item.py
@@ -19,7 +19,10 @@ logger = logging.getLogger(constant.LOGGER_NAME)
 REMOVE_LICENSE = ["warranty-disclaimer"]
 find_word = re.compile(rb"SPDX-PackageDownloadLocation\s*:\s*(\S+)", re.IGNORECASE)
 SPDX_LICENSE_IDENTIFIER_PATTERN = re.compile(
-    r'SPDX[-\s]+License[-\s]+Identifier(?:\s*[:,-]\s*|\s+)([^\r\n]+)',
+    # Require : , or - after Identifier. Bare whitespace is rejected so that
+    # messages like 'Misplaced SPDX-License-Identifier tag - use line ...'
+    # are not treated as license declarations.
+    r'SPDX[-\s]+License[-\s]+Identifier\s*[:,-]\s*([^\r\n]+)',
     re.IGNORECASE,
 )
 # Android Soong license_kinds string, e.g. "SPDX-license-identifier-BSD"
@@ -82,6 +85,17 @@ def _file_has_other_license(matches: list) -> bool:
     for matched_lic in matches or []:
         license_expression = matched_lic.get("license_expression") or ""
         if _expression_has_other_license(license_expression):
+            return True
+    return False
+
+
+def _file_has_spdx_declared_license(matches: list) -> bool:
+    """True if any non-unknown-spdx match has a recoverable SPDX-License-Identifier."""
+    for matched_lic in matches or []:
+        expr = (matched_lic.get("license_expression") or "").lower()
+        if KEYWORD_SCANCODE_UNKNOWN in expr:
+            continue
+        if _extract_spdx_declared_expression(matched_lic.get("matched_text") or ""):
             return True
     return False
 
@@ -575,6 +589,7 @@ def parsing_scancode(
                 for lic in licenses or []:
                     all_matches.extend(lic.get("matches") or [])
                 has_other_license_in_file = _file_has_other_license(all_matches)
+                has_spdx_declared_license = _file_has_spdx_declared_license(all_matches)
                 suppress_unknown_license_reference = (
                     _should_suppress_unknown_license_reference(
                         all_matches, has_other_license_in_file
@@ -592,6 +607,16 @@ def parsing_scancode(
                                 if declared:
                                     found_lic_list = declared
                                     resolved_unknown_spdx = True
+                                elif has_spdx_declared_license:
+                                    # File already has SPDX declarations; drop unrestorable
+                                    # unknown-spdx noise (e.g. misplaced-tag messages).
+                                    tokens = [
+                                        t for t in split_spdx_expression(found_lic_list)
+                                        if KEYWORD_SCANCODE_UNKNOWN not in t.lower()
+                                    ]
+                                    if not tokens:
+                                        continue
+                                    found_lic_list = " AND ".join(tokens)
                             for found_lic in split_spdx_expression(found_lic_list):
                                 if found_lic:
                                     found_lic = found_lic.strip()
@@ -609,6 +634,8 @@ def parsing_scancode(
                                         if declared:
                                             found_lic = declared
                                             resolved_unknown_spdx = True
+                                        elif has_spdx_declared_license:
+                                            continue
                                     found_lic = _strip_license_ref_prefix(found_lic)
                                     found_lic = _normalize_license_token(found_lic) or found_lic
                                     if not found_lic:

--- a/src/fosslight_source/_parsing_scancode_file_item.py
+++ b/src/fosslight_source/_parsing_scancode_file_item.py
@@ -90,7 +90,7 @@ def _file_has_other_license(matches: list) -> bool:
 
 
 def _matched_text_has_spdx_license_identifier(matched_txt: str) -> bool:
-    """True for classic 'SPDX-License-Identifier:' (colon). Soong dash form does not count."""
+    """True for classic SPDX-License-Identifier with a colon. Soong dash form does not count."""
     return bool(
         re.search(
             r'SPDX[-\s]+License[-\s]+Identifier\s*:\s*\S',
@@ -118,7 +118,7 @@ def _is_spdx_declaration_line(matched_txt: str) -> bool:
 
 
 def _file_has_spdx_license_identifier(matches: list) -> bool:
-    """True if any match is a classic SPDX-License-Identifier: declaration line."""
+    """True if any match is a classic SPDX-License-Identifier declaration line (colon form)."""
     return any(
         _is_spdx_declaration_line(m.get("matched_text") or "")
         and _matched_text_has_spdx_license_identifier(m.get("matched_text") or "")

--- a/src/fosslight_source/_parsing_scancode_file_item.py
+++ b/src/fosslight_source/_parsing_scancode_file_item.py
@@ -89,15 +89,57 @@ def _file_has_other_license(matches: list) -> bool:
     return False
 
 
+def _matched_text_has_spdx_license_identifier(matched_txt: str) -> bool:
+    """True for classic 'SPDX-License-Identifier:' (colon). Soong dash form does not count."""
+    return bool(
+        re.search(
+            r'SPDX[-\s]+License[-\s]+Identifier\s*:\s*\S',
+            matched_txt or "",
+            flags=re.IGNORECASE,
+        )
+    )
+
+
+def _is_spdx_declaration_line(matched_txt: str) -> bool:
+    """
+    True when matched_text is (mostly) an SPDX declaration line, not code that
+    merely mentions SPDX-License-Identifier (e.g. sed replacements).
+    """
+    if not _extract_spdx_declared_expression(matched_txt):
+        return False
+    stripped = re.sub(r"""^[\s"'#/\*-]+""", "", (matched_txt or "").strip())
+    return bool(
+        re.match(
+            r"SPDX[-\s]+License[-\s]+Identifier\s*[:,-]",
+            stripped,
+            flags=re.IGNORECASE,
+        )
+    )
+
+
+def _file_has_spdx_license_identifier(matches: list) -> bool:
+    """True if any match is a classic SPDX-License-Identifier: declaration line."""
+    return any(
+        _is_spdx_declaration_line(m.get("matched_text") or "")
+        and _matched_text_has_spdx_license_identifier(m.get("matched_text") or "")
+        for m in (matches or [])
+    )
+
+
 def _file_has_spdx_declared_license(matches: list) -> bool:
-    """True if any non-unknown-spdx match has a recoverable SPDX-License-Identifier."""
+    """True if any match has a recoverable SPDX declaration (incl. Soong kinds)."""
     for matched_lic in matches or []:
-        expr = (matched_lic.get("license_expression") or "").lower()
-        if KEYWORD_SCANCODE_UNKNOWN in expr:
-            continue
         if _extract_spdx_declared_expression(matched_lic.get("matched_text") or ""):
             return True
     return False
+
+
+def _filter_spdx_declaration_matches(matches: list) -> list:
+    """Keep only matches that are SPDX declaration lines (not code mentions)."""
+    return [
+        matched_lic for matched_lic in (matches or [])
+        if _is_spdx_declaration_line(matched_lic.get("matched_text") or "")
+    ]
 
 
 def _matched_text_has_http_url(matched_text: str) -> bool:
@@ -588,66 +630,86 @@ def parsing_scancode(
                 all_matches = []
                 for lic in licenses or []:
                     all_matches.extend(lic.get("matches") or [])
-                has_other_license_in_file = _file_has_other_license(all_matches)
+                # SPDX priority: if the file has SPDX-License-Identifier (:/,/-),
+                # keep only matches that are SPDX declarations (drop body rule hits).
+                prefer_spdx_declarations = _file_has_spdx_license_identifier(all_matches)
+                matches_to_process = (
+                    _filter_spdx_declaration_matches(all_matches)
+                    if prefer_spdx_declarations
+                    else list(all_matches or [])
+                )
+                has_other_license_in_file = _file_has_other_license(matches_to_process)
                 has_spdx_declared_license = _file_has_spdx_declared_license(all_matches)
                 suppress_unknown_license_reference = (
                     _should_suppress_unknown_license_reference(
-                        all_matches, has_other_license_in_file
+                        matches_to_process, has_other_license_in_file
                     )
                 )
-                for lic in licenses or []:
-                    matched_lic_list = lic.get("matches", [])
-                    for matched_lic in matched_lic_list:
-                        found_lic_list = matched_lic.get("license_expression", "")
-                        matched_txt = matched_lic.get("matched_text", "")
-                        if found_lic_list:
-                            found_lic_list = found_lic_list.lower()
-                            if KEYWORD_SCANCODE_UNKNOWN in found_lic_list:
+                spdx_declared_expressions: list[str] = []
+                for matched_lic in matches_to_process:
+                    found_lic_list = matched_lic.get("license_expression", "")
+                    matched_txt = matched_lic.get("matched_text", "")
+                    if prefer_spdx_declarations:
+                        declared = _extract_spdx_declared_expression(matched_txt)
+                        if not declared:
+                            continue
+                        found_lic_list = declared
+                        spdx_declared_expressions.append(declared)
+                        resolved_unknown_spdx = True
+                    elif found_lic_list:
+                        found_lic_list = found_lic_list.lower()
+                        if KEYWORD_SCANCODE_UNKNOWN in found_lic_list:
+                            declared = _extract_spdx_declared_expression(matched_txt)
+                            if declared:
+                                found_lic_list = declared
+                                resolved_unknown_spdx = True
+                            elif has_spdx_declared_license:
+                                # File already has SPDX declarations; drop unrestorable
+                                # unknown-spdx noise (e.g. misplaced-tag messages).
+                                tokens = [
+                                    t for t in split_spdx_expression(found_lic_list)
+                                    if KEYWORD_SCANCODE_UNKNOWN not in t.lower()
+                                ]
+                                if not tokens:
+                                    continue
+                                found_lic_list = " AND ".join(tokens)
+                    else:
+                        continue
+
+                    for found_lic in split_spdx_expression(found_lic_list):
+                        if found_lic:
+                            found_lic = found_lic.strip()
+                            if found_lic in REMOVE_LICENSE:
+                                continue
+                            if (
+                                KEYWORD_UNKNOWN_LICENSE_REFERENCE in found_lic.lower()
+                                and not _should_keep_unknown_license_reference(
+                                    matched_txt, has_other_license_in_file
+                                )
+                            ):
+                                continue
+                            if (
+                                not prefer_spdx_declarations
+                                and KEYWORD_SCANCODE_UNKNOWN in found_lic.lower()
+                            ):
                                 declared = _extract_spdx_declared_expression(matched_txt)
                                 if declared:
-                                    found_lic_list = declared
+                                    found_lic = declared
                                     resolved_unknown_spdx = True
                                 elif has_spdx_declared_license:
-                                    # File already has SPDX declarations; drop unrestorable
-                                    # unknown-spdx noise (e.g. misplaced-tag messages).
-                                    tokens = [
-                                        t for t in split_spdx_expression(found_lic_list)
-                                        if KEYWORD_SCANCODE_UNKNOWN not in t.lower()
-                                    ]
-                                    if not tokens:
-                                        continue
-                                    found_lic_list = " AND ".join(tokens)
-                            for found_lic in split_spdx_expression(found_lic_list):
-                                if found_lic:
-                                    found_lic = found_lic.strip()
-                                    if found_lic in REMOVE_LICENSE:
-                                        continue
-                                    if (
-                                        KEYWORD_UNKNOWN_LICENSE_REFERENCE in found_lic.lower()
-                                        and not _should_keep_unknown_license_reference(
-                                            matched_txt, has_other_license_in_file
-                                        )
-                                    ):
-                                        continue
-                                    if KEYWORD_SCANCODE_UNKNOWN in found_lic.lower():
-                                        declared = _extract_spdx_declared_expression(matched_txt)
-                                        if declared:
-                                            found_lic = declared
-                                            resolved_unknown_spdx = True
-                                        elif has_spdx_declared_license:
-                                            continue
-                                    found_lic = _strip_license_ref_prefix(found_lic)
-                                    found_lic = _normalize_license_token(found_lic) or found_lic
-                                    if not found_lic:
-                                        continue
-                                    if matched_txt:
-                                        lic_matched_key = found_lic + matched_txt
-                                        if lic_matched_key in license_list:
-                                            license_list[lic_matched_key].set_files(file_path)
-                                        else:
-                                            lic_info = MatchedLicense(found_lic, "", matched_txt, file_path)
-                                            license_list[lic_matched_key] = lic_info
-                                    license_detected.append(found_lic)
+                                    continue
+                            found_lic = _strip_license_ref_prefix(found_lic)
+                            found_lic = _normalize_license_token(found_lic) or found_lic
+                            if not found_lic:
+                                continue
+                            if matched_txt:
+                                lic_matched_key = found_lic + matched_txt
+                                if lic_matched_key in license_list:
+                                    license_list[lic_matched_key].set_files(file_path)
+                                else:
+                                    lic_info = MatchedLicense(found_lic, "", matched_txt, file_path)
+                                    license_list[lic_matched_key] = lic_info
+                            license_detected.append(found_lic)
                 result_item.licenses = license_detected
                 file_ext = os.path.splitext(file_path)[1].lower()
                 is_source_file = file_ext and file_ext in SOURCE_EXTENSIONS
@@ -662,29 +724,43 @@ def parsing_scancode(
                 )
 
                 if len(license_detected) > 1:
-                    detected_expression = file.get("detected_license_expression", "") or ""
-                    detected_expression_spdx = file.get("detected_license_expression_spdx", "") or ""
-                    if (
-                        resolved_unknown_spdx
-                        or KEYWORD_SCANCODE_UNKNOWN in detected_expression.lower()
-                        or "licenseref-scancode-unknown-spdx" in detected_expression_spdx.lower()
-                        or suppress_unknown_license_reference
-                    ):
-                        # Prefer non-SPDX expression so unknown-spdx tokens map cleanly.
-                        # Comment only for dual-license style expressions that include OR.
-                        source_expression = detected_expression or detected_expression_spdx
-                        if source_expression and "OR" in source_expression.upper():
-                            result_item.comment = build_comment_from_detected_expression(
-                                source_expression,
-                                all_matches,
-                                suppress_unknown_license_reference,
-                            )
+                    if prefer_spdx_declarations:
+                        # Comment from SPDX declarations only (ignore ScanCode aggregate).
+                        for declared in spdx_declared_expressions:
+                            if "OR" in declared.upper():
+                                tokens, ops = split_spdx_expression_with_ops(declared)
+                                norms = [
+                                    _normalize_license_token(token) or token
+                                    for token in tokens
+                                ]
+                                result_item.comment = _omit_parens_for_two_license_expression(
+                                    join_licenses_with_ops(norms, ops)
+                                )
+                                break
                     else:
-                        license_expression = detected_expression_spdx or detected_expression
-                        if license_expression and "OR" in license_expression:
-                            result_item.comment = _omit_parens_for_two_license_expression(
-                                license_expression
-                            )
+                        detected_expression = file.get("detected_license_expression", "") or ""
+                        detected_expression_spdx = file.get("detected_license_expression_spdx", "") or ""
+                        if (
+                            resolved_unknown_spdx
+                            or KEYWORD_SCANCODE_UNKNOWN in detected_expression.lower()
+                            or "licenseref-scancode-unknown-spdx" in detected_expression_spdx.lower()
+                            or suppress_unknown_license_reference
+                        ):
+                            # Prefer non-SPDX expression so unknown-spdx tokens map cleanly.
+                            # Comment only for dual-license style expressions that include OR.
+                            source_expression = detected_expression or detected_expression_spdx
+                            if source_expression and "OR" in source_expression.upper():
+                                result_item.comment = build_comment_from_detected_expression(
+                                    source_expression,
+                                    matches_to_process,
+                                    suppress_unknown_license_reference,
+                                )
+                        else:
+                            license_expression = detected_expression_spdx or detected_expression
+                            if license_expression and "OR" in license_expression:
+                                result_item.comment = _omit_parens_for_two_license_expression(
+                                    license_expression
+                                )
 
                 scancode_file_item.append(result_item)
             except Exception as ex:

--- a/tests/test_parsing_unknown_spdx.py
+++ b/tests/test_parsing_unknown_spdx.py
@@ -21,7 +21,6 @@ from fosslight_source._parsing_scancode_file_item import (
         ("// SPDX-License-Identifier: MIT", "MIT"),
         ("// SPDX-License-Identifier-MIT", "MIT"),
         ("// SPDX-License-Identifier, MIT", "MIT"),
-        ("// SPDX-License-Identifier MIT", "MIT"),
         ('        "SPDX-license-identifier-BSD",', "BSD"),
         ('        "SPDX-license-identifier-OFL", // by exception only', "OFL"),
         ("/* SPDX-License-Identifier: MIT */", "MIT"),
@@ -39,6 +38,20 @@ from fosslight_source._parsing_scancode_file_item import (
 )
 def test_extract_spdx_declared_expression(matched_text, expected):
     assert _extract_spdx_declared_expression(matched_text) == expected
+
+
+@pytest.mark.parametrize(
+    "matched_text",
+    [
+        "// SPDX-License-Identifier MIT",
+        (
+            '\t\t\t     "Misplaced SPDX-License-Identifier tag - use line '
+            '$checklicenseline instead " . $herecurr);'
+        ),
+    ],
+)
+def test_extract_spdx_rejects_whitespace_only_separator(matched_text):
+    assert _extract_spdx_declared_expression(matched_text) == ""
 
 
 def test_declared_licenses_strips_licenseref_per_token():
@@ -238,7 +251,7 @@ def test_unknown_license_reference_suppressed_by_other_license_in_same_file():
     success, results, _messages, license_list = parsing_scancode(scancode_file_list)
 
     assert success is True
-    assert results[0].licenses == ["MIT", "Apache-2.0"]
+    assert results[0].licenses == ["Apache-2.0", "MIT"]
     assert results[0].comment == "MIT OR Apache-2.0"
     assert all(
         item.license != "unknown-license-reference"
@@ -499,12 +512,46 @@ def test_android_bp_soong_license_kinds_without_line_comment_in_license():
 
     assert success is True
     licenses = results[0].licenses
+    # unknown-license-reference has no URL and other licenses exist → suppressed
     assert licenses == [
         "Apache-2.0",
         "BSD",
         "MIT",
         "OFL",
-        "unknown-license-reference",
     ]
     assert all("//" not in lic for lic in results[0].licenses)
     assert all('"' not in lic for lic in results[0].licenses)
+
+
+def test_ignore_unknown_spdx_when_file_has_spdx_declaration():
+    """tag.pl-like: real SPDX tag present → ignore misplaced unknown-spdx match."""
+    scancode_file_list = [{
+        "path": "tag.pl",
+        "type": "file",
+        "detected_license_expression": "gpl-2.0 AND unknown-spdx",
+        "license_detections": [
+            {
+                "matches": [{
+                    "license_expression": "gpl-2.0",
+                    "matched_text": "# SPDX-License-Identifier: GPL-2.0",
+                }],
+            },
+            {
+                "matches": [{
+                    "license_expression": "unknown-spdx",
+                    "matched_text": (
+                        '\t\t\t     "Misplaced SPDX-License-Identifier tag - use line '
+                        '$checklicenseline instead " . $herecurr);'
+                    ),
+                }],
+            },
+        ],
+        "copyrights": [],
+    }]
+
+    success, results, _messages, _ = parsing_scancode(scancode_file_list)
+
+    assert success is True
+    assert results[0].licenses == ["GPL-2.0"]
+    assert all("unknown" not in lic.lower() for lic in results[0].licenses)
+    assert all("tag" not in lic.lower() for lic in results[0].licenses)

--- a/tests/test_parsing_unknown_spdx.py
+++ b/tests/test_parsing_unknown_spdx.py
@@ -141,9 +141,10 @@ def test_unknown_spdx_comment_preserves_and_or_from_detected_expression():
     success, results, _messages, _ = parsing_scancode(scancode_file_list)
 
     assert success is True
-    assert results[0].licenses == ["DApache-2.0", "GPL-2.0", "NEW"]
+    # SPDX-License-Identifier: present → SPDX priority drops non-declaration gpl-2.0 match
+    assert results[0].licenses == ["DApache-2.0", "NEW"]
     assert "unknown-license-reference" not in [lic.lower() for lic in results[0].licenses]
-    assert results[0].comment == "NEW OR DApache-2.0 AND GPL-2.0"
+    assert results[0].comment == "NEW OR DApache-2.0"
 
 
 def test_unknown_license_reference_suppressed_when_same_matched_text_has_other_license():
@@ -524,9 +525,9 @@ def test_android_bp_soong_license_kinds_without_line_comment_in_license():
 
 
 def test_ignore_unknown_spdx_when_file_has_spdx_declaration():
-    """tag.pl-like: real SPDX tag present → ignore misplaced unknown-spdx match."""
+    """SPDX-License-Identifier present → ignore unrestorable unknown-spdx match."""
     scancode_file_list = [{
-        "path": "tag.pl",
+        "path": "sample.c",
         "type": "file",
         "detected_license_expression": "gpl-2.0 AND unknown-spdx",
         "license_detections": [
@@ -555,3 +556,52 @@ def test_ignore_unknown_spdx_when_file_has_spdx_declaration():
     assert results[0].licenses == ["GPL-2.0"]
     assert all("unknown" not in lic.lower() for lic in results[0].licenses)
     assert all("tag" not in lic.lower() for lic in results[0].licenses)
+
+
+def test_spdx_priority_drops_body_rule_matches():
+    """When SPDX-License-Identifier: exists, keep declaration only; drop code mentions."""
+    scancode_file_list = [{
+        "path": "sample.c",
+        "type": "file",
+        "detected_license_expression": (
+            "gpl-2.0 AND (gpl-2.0 AND bsd-simplified AND (gpl-2.0 OR bsd-simplified))"
+        ),
+        "license_detections": [
+            {
+                "matches": [{
+                    "license_expression": "gpl-2.0",
+                    "matched_text": "# SPDX-License-Identifier: GPL-2.0",
+                }],
+            },
+            {
+                "matches": [
+                    {
+                        "license_expression": "gpl-2.0",
+                        "matched_text": (
+                            "\t\t\t\t\t    not $spdx_license =~ /GPL-2\\.0.*BSD-2-Clause/) {"
+                        ),
+                    },
+                    {
+                        "license_expression": "bsd-simplified",
+                        "matched_text": (
+                            "\t\t\t\t\t    not $spdx_license =~ /GPL-2\\.0.*BSD-2-Clause/) {"
+                        ),
+                    },
+                    {
+                        "license_expression": "gpl-2.0 OR bsd-simplified",
+                        "matched_text": (
+                            "DT binding documents should be licensed "
+                            "(GPL-2.0-only OR BSD-2-Clause)"
+                        ),
+                    },
+                ],
+            },
+        ],
+        "copyrights": [],
+    }]
+
+    success, results, _messages, _ = parsing_scancode(scancode_file_list)
+
+    assert success is True
+    assert results[0].licenses == ["GPL-2.0"]
+    assert results[0].comment == ""

--- a/tests/test_parsing_unknown_spdx.py
+++ b/tests/test_parsing_unknown_spdx.py
@@ -141,7 +141,8 @@ def test_unknown_spdx_comment_preserves_and_or_from_detected_expression():
     success, results, _messages, _ = parsing_scancode(scancode_file_list)
 
     assert success is True
-    # SPDX-License-Identifier: present → SPDX priority drops non-declaration gpl-2.0 match
+    # Classic SPDX-License-Identifier with colon present → SPDX priority drops
+    # non-declaration gpl-2.0 match
     assert results[0].licenses == ["DApache-2.0", "NEW"]
     assert "unknown-license-reference" not in [lic.lower() for lic in results[0].licenses]
     assert results[0].comment == "NEW OR DApache-2.0"
@@ -559,7 +560,7 @@ def test_ignore_unknown_spdx_when_file_has_spdx_declaration():
 
 
 def test_spdx_priority_drops_body_rule_matches():
-    """When SPDX-License-Identifier: exists, keep declaration only; drop code mentions."""
+    """When classic SPDX-License-Identifier with colon exists, keep declaration only."""
     scancode_file_list = [{
         "path": "sample.c",
         "type": "file",


### PR DESCRIPTION
## Summary
- Ignore `unknown-spdx` when the file already has a recoverable SPDX-License-Identifier and the unknown match cannot be restored (e.g. misplaced-tag messages).
- Require `:`, `,`, or `-` after `SPDX-License-Identifier` (no whitespace-only separator).
- Successfully restored Soong `SPDX-license-identifier-*` values are still kept.
